### PR TITLE
Implement Catch2 Integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(leetspace)
 
+include(cmake/CPM.cmake)
+
 enable_testing()
 
 add_subdirectory(problems)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,7 @@ include(cmake/CPM.cmake)
 
 enable_testing()
 
+cpmaddpackage("gh:catchorg/Catch2@3.4.0")
+include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
+
 add_subdirectory(problems)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -1,0 +1,31 @@
+set(CPM_DOWNLOAD_VERSION 0.38.2)
+
+if(CPM_SOURCE_CACHE)
+  set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+elseif(DEFINED ENV{CPM_SOURCE_CACHE})
+  set(CPM_DOWNLOAD_LOCATION "$ENV{CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+else()
+  set(CPM_DOWNLOAD_LOCATION "${CMAKE_BINARY_DIR}/cmake/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
+endif()
+
+# Expand relative path. This is important if the provided path contains a tilde (~)
+get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
+
+function(download_cpm)
+  message(STATUS "Downloading CPM.cmake to ${CPM_DOWNLOAD_LOCATION}")
+  file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
+       ${CPM_DOWNLOAD_LOCATION})
+endfunction()
+
+if(NOT (EXISTS ${CPM_DOWNLOAD_LOCATION}))
+  download_cpm()
+else()
+  # resume download if it previously failed
+  file(READ ${CPM_DOWNLOAD_LOCATION} check)
+  if("${check}" STREQUAL "")
+    download_cpm()
+  endif()
+  unset(check)
+endif()
+
+include(${CPM_DOWNLOAD_LOCATION})

--- a/problems/2235-add-two-integers/main.cpp
+++ b/problems/2235-add-two-integers/main.cpp
@@ -1,9 +1,0 @@
-#include <cassert>
-
-#include "solution.cpp"
-
-int main() {
-    Solution solution;
-    assert(solution.sum(12, 5) == 17);
-    assert(solution.sum(-10, 4) == -6);
-}

--- a/problems/2235-add-two-integers/test.cpp
+++ b/problems/2235-add-two-integers/test.cpp
@@ -1,0 +1,9 @@
+#include <catch2/catch_test_macros.hpp>
+#include "solution.cpp"
+
+TEST_CASE("2235. Add Two Integers") {
+  Solution solution;
+
+  CHECK(solution.sum(12, 5) == 17);
+  CHECK(solution.sum(-10, 4) == -6);
+}

--- a/problems/2235-add-two-integers/test.cpp
+++ b/problems/2235-add-two-integers/test.cpp
@@ -4,6 +4,11 @@
 TEST_CASE("2235. Add Two Integers") {
   Solution solution;
 
-  CHECK(solution.sum(12, 5) == 17);
-  CHECK(solution.sum(-10, 4) == -6);
+  SECTION("Testcase 1") {
+    CHECK(solution.sum(12, 5) == 17);
+  }
+
+  SECTION("Testcase 2") {
+    CHECK(solution.sum(-10, 4) == -6);
+  }
 }

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(PROBLEMS 2235-add-two-integers)
 
 foreach(PROBLEM ${PROBLEMS})
-  add_executable(${PROBLEM} ${PROBLEM}/main.cpp)
-  add_test(NAME ${PROBLEM} COMMAND ${PROBLEM})
+  add_executable(${PROBLEM} ${PROBLEM}/test.cpp)
+  target_link_libraries(${PROBLEM} PRIVATE Catch2::Catch2WithMain)
+  catch_discover_tests(${PROBLEM})
 endforeach()


### PR DESCRIPTION
This pull request resolves #5 by integrating [Catch2](https://github.com/catchorg/Catch2) for more robust solution testing.