### PR TITLE
Clang-Format Configure Column Limit

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,2 @@
 BasedOnStyle: Google
+ColumnLimit: 0


### PR DESCRIPTION
This pull request simply configure the column limit of Clang-Format to `0`.