### PR TITLE
Implement Package Lock and Caching for CPM Dependencies

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,3 +1,14 @@
 {
+    "additional_commands": {
+        "cpmdeclarepackage": {
+            "kwargs": {
+                "VERSION": 1,
+                "GITHUB_REPOSITORY": 1,
+                "SYSTEM": 1,
+                "EXCLUDE_FROM_ALL": 1
+            }
+        }
+    },
+    "enable_markup": false,
     "line_width": 120
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Install cmake-format
         run: pipx install cmake-format --include-deps
 
+      - name: Cache deps build
+        uses: actions/cache@v3.3.2
+        with:
+          path: build/_deps
+          key: CPM-${{ runner.os }}-${{ hashFiles('package-lock.cmake') }}
+
       - name: Configure and build
         uses: threeal/cmake-action@v1.3.0
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project(leetspace)
 
 include(cmake/CPM.cmake)
 
-cpmaddpackage("gh:TheLartians/Format.cmake@1.7.3")
+cpmgetpackage(Format.cmake)
 
 enable_testing()
 
-cpmaddpackage("gh:catchorg/Catch2@3.4.0")
+cpmgetpackage(Catch2)
 include("${Catch2_SOURCE_DIR}/extras/Catch.cmake")
 
 add_subdirectory(problems)

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -20,3 +20,4 @@ file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DO
      ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM})
 
 include(${CPM_DOWNLOAD_LOCATION})
+cpmusepackagelock(package-lock.cmake)

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -2,16 +2,16 @@
 # This file should be committed to version control
 
 # Format.cmake
-CPMDeclarePackage(Format.cmake
+cpmdeclarepackage(
+  Format.cmake
   VERSION 1.7.3
   GITHUB_REPOSITORY TheLartians/Format.cmake
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES
-)
+  EXCLUDE_FROM_ALL YES)
 # Catch2
-CPMDeclarePackage(Catch2
+cpmdeclarepackage(
+  Catch2
   VERSION 3.4.0
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES
-)
+  EXCLUDE_FROM_ALL YES)

--- a/package-lock.cmake
+++ b/package-lock.cmake
@@ -1,0 +1,17 @@
+# CPM Package Lock
+# This file should be committed to version control
+
+# Format.cmake
+CPMDeclarePackage(Format.cmake
+  VERSION 1.7.3
+  GITHUB_REPOSITORY TheLartians/Format.cmake
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)
+# Catch2
+CPMDeclarePackage(Catch2
+  VERSION 3.4.0
+  GITHUB_REPOSITORY catchorg/Catch2
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)


### PR DESCRIPTION
This pull request includes the following changes:

- Implements a CPM package lock that lists all CPM dependencies in this project.
- Adds a step in the CI workflow to cache the CPM dependencies build.

Resolves #13.