### PR TITLE
Update Minimum CMake Version to `3.5`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(leetspace)
 


### PR DESCRIPTION
This pull request straightforwardly updates the minimum required CMake version to `3.5`.