### PR TITLE
Configure Clang Format for Non-Aligned Operands

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
+AlignOperands: DontAlign
 BasedOnStyle: Google
 ColumnLimit: 0


### PR DESCRIPTION
This pull request makes a simple configuration adjustment to Clang-Format, preventing the alignment of operands.