### PR TITLE
Prevent Formatting of CPM Package Lock File

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -1,13 +1,5 @@
 {
     "additional_commands": {
-        "cpmdeclarepackage": {
-            "kwargs": {
-                "VERSION": 1,
-                "GITHUB_REPOSITORY": 1,
-                "SYSTEM": 1,
-                "EXCLUDE_FROM_ALL": 1
-            }
-        },
         "file": {
         }
     },

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v3.3.2
         with:
           path: build/_deps
-          key: CPM-${{ runner.os }}-${{ hashFiles('package-lock.cmake') }}
+          key: CPM-${{ runner.os }}-${{ hashFiles('package-lock') }}
 
       - name: Configure and build
         uses: threeal/cmake-action@v1.3.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,11 @@ jobs:
         with:
           run-build: true
 
+      - name: Check package lock
+        run: |
+          cmake --build build --target cpm-update-package-lock
+          git diff --exit-code HEAD
+
       - name: Check format
         run: |
           cmake --build build --target fix-format

--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -20,4 +20,4 @@ file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DO
      ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM})
 
 include(${CPM_DOWNLOAD_LOCATION})
-cpmusepackagelock(package-lock.cmake)
+cpmusepackagelock(package-lock)

--- a/package-lock
+++ b/package-lock
@@ -2,16 +2,16 @@
 # This file should be committed to version control
 
 # Format.cmake
-cpmdeclarepackage(
-  Format.cmake
+CPMDeclarePackage(Format.cmake
   VERSION 1.7.3
   GITHUB_REPOSITORY TheLartians/Format.cmake
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES)
+  EXCLUDE_FROM_ALL YES
+)
 # Catch2
-cpmdeclarepackage(
-  Catch2
+CPMDeclarePackage(Catch2
   VERSION 3.4.0
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
-  EXCLUDE_FROM_ALL YES)
+  EXCLUDE_FROM_ALL YES
+)


### PR DESCRIPTION
This pull request ensures that the CPM package lock file is not subjected to formatting by making the following changes:

- Renamed the CPM package lock file to `package-lock`.
- Removed the configuration for the `cpmdeclarepackage` function in the cmake-format configuration.
- Added a workflow step to verify the correct updating of the CPM package lock file.

This change resolves #53.