### PR TITLE
Workflow Remove Check Package Lock Step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,11 +26,6 @@ jobs:
         with:
           run-build: true
 
-      - name: Check package lock
-        run: |
-          cmake --build build --target cpm-update-package-lock
-          git diff --exit-code HEAD
-
       - name: Check format
         run: |
           cmake --build build --target fix-format


### PR DESCRIPTION
This pull request simply remove the "Check package lock" step from the workflow. 