### PR TITLE
Generate C++ Header from YAML Test Cases

### DIFF
--- a/internal/CMakeLists.txt
+++ b/internal/CMakeLists.txt
@@ -1,1 +1,2 @@
+add_subdirectory(generators)
 add_subdirectory(utils)

--- a/internal/generators/CMakeLists.txt
+++ b/internal/generators/CMakeLists.txt
@@ -1,0 +1,15 @@
+macro(add_test_cases target)
+  get_dir_name(id)
+  set(${target} test-cases-${id})
+
+  foreach(arg ${ARGN})
+    set(output ${CMAKE_CURRENT_BINARY_DIR}/${arg})
+    add_custom_command(
+      OUTPUT ${output}
+      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${arg} ${output}
+      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
+      VERBATIM)
+    list(APPEND outputs ${output})
+  endforeach()
+  add_custom_target(test-cases-${id} DEPENDS ${outputs})
+endmacro()

--- a/internal/generators/CMakeLists.txt
+++ b/internal/generators/CMakeLists.txt
@@ -7,15 +7,26 @@ macro(add_test_cases target)
     message(FATAL_ERROR "Could not find Python")
   endif()
 
+  # Generate C++ headers from YAML test cases files.
   foreach(arg ${ARGN})
-    set(output ${CMAKE_CURRENT_BINARY_DIR}/${arg})
+    get_filename_component(ARG_WE ${arg} NAME_WE)
     add_custom_command(
-      OUTPUT ${output}
-      COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/internal/generators/copy.py ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
-              ${output}
+      OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/include/${ARG_WE}.hpp
+      COMMAND mkdir -p ${CMAKE_CURRENT_BINARY_DIR}/include
+      COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/internal/generators/generate_test_cases.py
+              ${CMAKE_CURRENT_SOURCE_DIR}/${arg} ${CMAKE_CURRENT_BINARY_DIR}/include/${ARG_WE}.hpp
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
       VERBATIM)
-    list(APPEND outputs ${output})
+    list(APPEND outputs ${CMAKE_CURRENT_BINARY_DIR}/include/${ARG_WE}.hpp)
   endforeach()
-  add_custom_target(test-cases-${id} DEPENDS ${outputs})
+  add_custom_target(test-cases-${id}-hpp DEPENDS ${outputs})
+
+  cpmgetpackage(yaml-cpp)
+
+  # Add a test case target that includes the generated C++ headers.
+  add_library(test-cases-${id} INTERFACE)
+  target_include_directories(test-cases-${id} INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/include)
+  target_link_libraries(test-cases-${id} INTERFACE yaml-cpp)
+
+  add_dependencies(test-cases-${id} test-cases-${id}-hpp)
 endmacro()

--- a/internal/generators/CMakeLists.txt
+++ b/internal/generators/CMakeLists.txt
@@ -2,11 +2,17 @@ macro(add_test_cases target)
   get_dir_name(id)
   set(${target} test-cases-${id})
 
+  find_package(Python)
+  if(NOT Python_FOUND)
+    message(FATAL_ERROR "Could not find Python")
+  endif()
+
   foreach(arg ${ARGN})
     set(output ${CMAKE_CURRENT_BINARY_DIR}/${arg})
     add_custom_command(
       OUTPUT ${output}
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${arg} ${output}
+      COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/internal/generators/copy.py ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
+              ${output}
       DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
       VERBATIM)
     list(APPEND outputs ${output})

--- a/internal/generators/copy.py
+++ b/internal/generators/copy.py
@@ -1,0 +1,4 @@
+import shutil
+import sys
+
+shutil.copy(sys.argv[1], sys.argv[2])

--- a/internal/generators/copy.py
+++ b/internal/generators/copy.py
@@ -1,4 +1,0 @@
-import shutil
-import sys
-
-shutil.copy(sys.argv[1], sys.argv[2])

--- a/internal/generators/generate_test_cases.py
+++ b/internal/generators/generate_test_cases.py
@@ -1,0 +1,10 @@
+import sys
+
+with open(sys.argv[2], "w") as dst:
+    dst.write("#include <yaml-cpp/yaml.h>\n\n")
+    dst.write("const auto test_cases = YAML::Load(R\"(\n")
+
+    with open(sys.argv[1], "r") as src:
+        dst.write(src.read())
+
+    dst.write(")\");\n")

--- a/problems/0001/CMakeLists.txt
+++ b/problems/0001/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.c c/interface.cpp)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/0001/test.cpp
+++ b/problems/0001/test.cpp
@@ -1,13 +1,11 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1. Two Sum") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0003/CMakeLists.txt
+++ b/problems/0003/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0003/test.cpp
+++ b/problems/0003/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("3. Longest Substring Without Repeating Characters") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0004/CMakeLists.txt
+++ b/problems/0004/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0004/test.cpp
+++ b/problems/0004/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("4. Median of Two Sorted Arrays") {
-  auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums1 = test_case["nums1"].as<std::vector<int>>();

--- a/problems/0005/CMakeLists.txt
+++ b/problems/0005/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.c c/interface.cpp)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/0005/test.cpp
+++ b/problems/0005/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("5. Longest Palindromic Substring") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto input = test_case["input"].as<std::string>();

--- a/problems/0006/CMakeLists.txt
+++ b/problems/0006/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.cpp c/interface.c)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/0006/test.cpp
+++ b/problems/0006/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("6. Zigzag Conversion") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0008/CMakeLists.txt
+++ b/problems/0008/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0008/test.cpp
+++ b/problems/0008/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("8. String to Integer (atoi)") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0009/CMakeLists.txt
+++ b/problems/0009/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0009/test.cpp
+++ b/problems/0009/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("9. Palindrome Number") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto x = test_case["x"].as<int>();

--- a/problems/0011/CMakeLists.txt
+++ b/problems/0011/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0011/test.cpp
+++ b/problems/0011/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("11. Container With Most Water") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto height = test_case["height"].as<std::vector<int>>();

--- a/problems/0015/CMakeLists.txt
+++ b/problems/0015/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0015/test.cpp
+++ b/problems/0015/test.cpp
@@ -1,13 +1,11 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("15. 3Sum") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0017/CMakeLists.txt
+++ b/problems/0017/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0017/test.cpp
+++ b/problems/0017/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("17. Letter Combinations of a Phone Number") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto digits = test_case["digits"].as<std::string>();

--- a/problems/0026/CMakeLists.txt
+++ b/problems/0026/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0026/test.cpp
+++ b/problems/0026/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("26. Remove Duplicates from Sorted Array") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0027/CMakeLists.txt
+++ b/problems/0027/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0027/test.cpp
+++ b/problems/0027/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("27. Remove Element") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0028/CMakeLists.txt
+++ b/problems/0028/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0028/test.cpp
+++ b/problems/0028/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("28. Find the Index of the First Occurrence in a String") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto haystack = test_case["haystack"].as<std::string>();

--- a/problems/0035/CMakeLists.txt
+++ b/problems/0035/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0035/test.cpp
+++ b/problems/0035/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("35. Search Insert Position") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0058/CMakeLists.txt
+++ b/problems/0058/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0058/test.cpp
+++ b/problems/0058/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("58. Length of Last Word") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0229/CMakeLists.txt
+++ b/problems/0229/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0229/test.cpp
+++ b/problems/0229/test.cpp
@@ -1,13 +1,11 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/matchers/catch_matchers_vector.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("229. Majority Element II") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/0316/CMakeLists.txt
+++ b/problems/0316/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0316/test.cpp
+++ b/problems/0316/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("316. Remove Duplicate Letters") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0343/CMakeLists.txt
+++ b/problems/0343/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0343/test.cpp
+++ b/problems/0343/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("343. Integer Break") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto n = test_case["n"].as<int>();

--- a/problems/0387/CMakeLists.txt
+++ b/problems/0387/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0387/test.cpp
+++ b/problems/0387/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("387. First Unique Character in a String") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0389/CMakeLists.txt
+++ b/problems/0389/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0389/test.cpp
+++ b/problems/0389/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("389. Find the Difference") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0392/CMakeLists.txt
+++ b/problems/0392/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0392/test.cpp
+++ b/problems/0392/test.cpp
@@ -1,13 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
-
-bool solution_cpp(std::string s, std::string t);
+#include <test_cases.hpp>
 
 TEST_CASE("392. Is Subsequence") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0557/CMakeLists.txt
+++ b/problems/0557/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.c c/interface.cpp)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/0557/test.cpp
+++ b/problems/0557/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("557. Reverse Words in a String III") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0880/CMakeLists.txt
+++ b/problems/0880/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.cpp c/interface.c)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} ${c_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution} ${c_solution})

--- a/problems/0880/test.cpp
+++ b/problems/0880/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("880. Decoded String at Index") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/0905/CMakeLists.txt
+++ b/problems/0905/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/0905/test.cpp
+++ b/problems/0905/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("905. Sort Array By Parity") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/1048/CMakeLists.txt
+++ b/problems/1048/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/1048/test.cpp
+++ b/problems/1048/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1048. Longest String Chain") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto words = test_case["words"].as<std::vector<std::string>>();

--- a/problems/1081/CMakeLists.txt
+++ b/problems/1081/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/1081/test.cpp
+++ b/problems/1081/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("1081. Smallest Subsequence of Distinct Characters") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto s = test_case["s"].as<std::string>();

--- a/problems/1232/CMakeLists.txt
+++ b/problems/1232/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/1232/test.cpp
+++ b/problems/1232/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1232. Check If It Is a Straight Line") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto coordinates = test_case["coordinates"].as<std::vector<std::vector<int>>>();

--- a/problems/1337/CMakeLists.txt
+++ b/problems/1337/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/1337/test.cpp
+++ b/problems/1337/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1337. The K Weakest Rows in a Matrix") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto mat = test_case["mat"].as<std::vector<std::vector<int>>>();

--- a/problems/1512/CMakeLists.txt
+++ b/problems/1512/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.c c/interface.cpp)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${c_solution} ${test_cases} ${cpp_solution})

--- a/problems/1512/test.cpp
+++ b/problems/1512/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1512. Number of Good Pairs") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/1658/CMakeLists.txt
+++ b/problems/1658/CMakeLists.txt
@@ -2,5 +2,4 @@ add_test_cases(test_cases test_cases.yaml)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${cpp_solution})

--- a/problems/1658/test.cpp
+++ b/problems/1658/test.cpp
@@ -1,12 +1,10 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 #include <vector>
 
 TEST_CASE("1658. Minimum Operations to Reduce X to Zero") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     auto name = test_case["name"].as<std::string>();
     auto nums = test_case["nums"].as<std::vector<int>>();

--- a/problems/2038/CMakeLists.txt
+++ b/problems/2038/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.c c/interface.cpp)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/2038/test.cpp
+++ b/problems/2038/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("2038. Remove Colored Pieces if Both Neighbors are the Same Color") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto colors = test_case["colors"].as<std::string>();

--- a/problems/2235/CMakeLists.txt
+++ b/problems/2235/CMakeLists.txt
@@ -3,5 +3,4 @@ add_c_solution(c_solution c/interface.cpp c/solution.c)
 add_cpp_solution(cpp_solution cpp/interface.cpp)
 
 add_problem_test(test test.cpp)
-target_link_libraries(${test} PRIVATE ${c_solution} ${cpp_solution} yaml-cpp)
-add_dependencies(${test} ${test_cases})
+target_link_libraries(${test} PRIVATE ${test_cases} ${c_solution} ${cpp_solution})

--- a/problems/2235/test.cpp
+++ b/problems/2235/test.cpp
@@ -1,11 +1,9 @@
-#include <yaml-cpp/yaml.h>
-
 #include <catch2/catch_test_macros.hpp>
 #include <interface.hpp>
 #include <string>
+#include <test_cases.hpp>
 
 TEST_CASE("2235. Add Two Integers") {
-  const auto test_cases = YAML::LoadFile("test_cases.yaml");
   for (const auto& test_case : test_cases) {
     const auto name = test_case["name"].as<std::string>();
     const auto num1 = test_case["num1"].as<int>();

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -2,22 +2,6 @@ macro(get_dir_name var)
   get_filename_component(${var} ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 endmacro()
 
-macro(add_test_cases target)
-  get_dir_name(id)
-  set(${target} test-cases-${id})
-
-  foreach(arg ${ARGN})
-    set(output ${CMAKE_CURRENT_BINARY_DIR}/${arg})
-    add_custom_command(
-      OUTPUT ${output}
-      COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/${arg} ${output}
-      DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${arg}
-      VERBATIM)
-    list(APPEND outputs ${output})
-  endforeach()
-  add_custom_target(test-cases-${id} DEPENDS ${outputs})
-endmacro()
-
 function(target_set_cpp_standard target)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
   target_compile_options(${target} PRIVATE -Werror -Wall -Wextra -Wpedantic)


### PR DESCRIPTION
This pull request generates C++ headers from YAML test cases. These headers essentially contain the string version of the content of the YAML file. While the YAML parsing still occurs in C++ during runtime, this pull request prevents the test executable from having to locate the YAML file since it is already included in the source files. This resolves #72.