### PR TITLE
Update CPM.cmake to Version 0.38.6

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.38.5)
-set(CPM_HASH_SUM "192aa0ccdc57dfe75bd9e4b176bf7fb5692fd2b3e3f7b09c74856fc39572b31c")
+set(CPM_DOWNLOAD_VERSION 0.38.6)
+set(CPM_HASH_SUM "11c3fa5f1ba14f15d31c2fb63dbc8628ee133d81c8d764caad9a8db9e0bacb07")
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")

--- a/package-lock
+++ b/package-lock
@@ -13,9 +13,9 @@ CPMDeclarePackage(yaml-cpp
   GIT_TAG 0.8.0
   GITHUB_REPOSITORY jbeder/yaml-cpp
   SYSTEM YES
+  EXCLUDE_FROM_ALL YES
   OPTIONS
     "YAML_CPP_FORMAT_SOURCE OFF"
-  EXCLUDE_FROM_ALL YES
 )
 # Catch2
 CPMDeclarePackage(Catch2


### PR DESCRIPTION
This pull request updates [CPM.cmake](https://github.com/cpm-cmake/CPM.cmake) to version [v0.38.6](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.38.6) and update the content of CPM's package lock file.