### PR TITLE
Add Dependabot Configuration to Check Poetry Dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,3 +7,12 @@ updates:
     commit-message:
       prefix: chore
     labels: [chore]
+
+  - package-ecosystem: pip
+    directory: /internal/python
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: chore
+    labels: [chore]
+    versioning-strategy: increase


### PR DESCRIPTION
This pull request introduces an entry in the `dependabot.yaml` configuration file to monitor and check for updates on Poetry dependencies used in the `internal/python` subproject. It closes #123.