### PR TITLE
Internal Python: Reorganize Script for Test Source File Generator

### DIFF
--- a/internal/python/lib/generate_test_src/__main__.py
+++ b/internal/python/lib/generate_test_src/__main__.py
@@ -3,6 +3,8 @@ import sys
 
 import yaml
 
+from .generators import generate_test_src
+
 
 def main():
     with open(sys.argv[1], "r") as config_file:
@@ -47,63 +49,4 @@ def main():
 
                 output.write("}\n")
 
-        with open(os.path.join(sys.argv[2], "test.cpp"), "w") as output:
-            output.write("#include <catch2/catch_test_macros.hpp>\n")
-            output.write("#include <string>\n")
-            output.write("#include <vector>\n")
-
-            output.write("\n")
-            for lang in config["solutions"]:
-                output.write("%s solution_%s(" % (config["types"]["output"], lang))
-                output.write(
-                    ", ".join(
-                        [
-                            ("%s %s" % (t, v))
-                            for v, t in config["types"]["inputs"].items()
-                        ]
-                    )
-                )
-                output.write(");\n")
-
-            output.write("\nstruct TestCase {\n")
-            output.write("  struct Inputs {\n")
-            for v, t in config["types"]["inputs"].items():
-                output.write("    %s %s;\n" % (t, v))
-            output.write("  };\n\n")
-            output.write("  std::string name;\n")
-            output.write("  Inputs inputs;\n")
-            output.write("  %s output;\n" % config["types"]["output"])
-            output.write("};\n")
-
-            def dump(data):
-                import json
-
-                s = json.dumps(data)
-                return s.replace("[", "{").replace("]", "}")
-
-            output.write("\nconst std::vector<TestCase> test_cases = {\n")
-            for name in config["test_cases"]:
-                cfg = config["test_cases"][name]
-                output.write("  {\n")
-                output.write('    .name = "%s",\n' % name)
-                output.write("    .inputs = {\n")
-                for var, val in cfg["inputs"].items():
-                    output.write("      .%s = %s,\n" % (var, dump(val)))
-                output.write("    },\n")
-                output.write("    .output = %s\n" % dump(cfg["output"]))
-                output.write("  },\n")
-            output.write("};\n")
-
-            for lang in config["solutions"]:
-                output.write('\nTEST_CASE("%s (%s)") {\n' % (config["name"], lang))
-                output.write(
-                    "  for (const auto& [name, inputs, output] : test_cases) {\n"
-                )
-
-                inputs = ", ".join(config["types"]["inputs"])
-                output.write("    const auto [%s] = inputs;\n" % inputs)
-                output.write("    CAPTURE(name, %s);\n" % inputs)
-                output.write("    CHECK(solution_%s(%s) == output);\n" % (lang, inputs))
-
-                output.write("  }\n")
-                output.write("}\n")
+        generate_test_src(sys.argv[2], config)

--- a/internal/python/lib/generate_test_src/__main__.py
+++ b/internal/python/lib/generate_test_src/__main__.py
@@ -3,7 +3,7 @@ import sys
 
 import yaml
 
-from .generators import generate_test_src
+from .generators import generate_solution_cpp_src, generate_test_src
 
 
 def main():
@@ -13,40 +13,5 @@ def main():
         if not os.path.exists(sys.argv[2]):
             os.makedirs(sys.argv[2])
 
-        with open(os.path.join(sys.argv[2], "solution_cpp.cpp"), "w") as output:
-            if "cpp" in config["solutions"]:
-                cfg = config["solutions"]["cpp"]
-
-                if cfg is not None and "includes" in cfg:
-                    for include in cfg["includes"]:
-                        output.write("#include <%s>\n" % include)
-                    output.write("\nusing namespace std;\n\n")
-
-                with open(
-                    os.path.join(os.path.dirname(sys.argv[1]), "solution.cpp"), "r"
-                ) as source:
-                    for line in source.readlines():
-                        output.write(line)
-
-                output.write("\n%s solution_cpp(" % config["types"]["output"])
-                output.write(
-                    ", ".join(
-                        [
-                            ("%s %s" % (t, v))
-                            for v, t in config["types"]["inputs"].items()
-                        ]
-                    )
-                )
-                output.write(") {\n")
-
-                output.write("  auto output = Solution().%s(" % cfg["function"])
-                output.write(", ".join(config["types"]["inputs"]))
-                output.write(");\n")
-
-                output.write(
-                    "  return %s;\n" % (cfg["output"] if "output" in cfg else "output")
-                )
-
-                output.write("}\n")
-
+        generate_solution_cpp_src(os.path.dirname(sys.argv[1]), sys.argv[2], config)
         generate_test_src(sys.argv[2], config)

--- a/internal/python/lib/generate_test_src/generators/__init__.py
+++ b/internal/python/lib/generate_test_src/generators/__init__.py
@@ -1,0 +1,1 @@
+from .test_src import generate_test_src

--- a/internal/python/lib/generate_test_src/generators/__init__.py
+++ b/internal/python/lib/generate_test_src/generators/__init__.py
@@ -1,1 +1,2 @@
+from .solution_cpp_src import generate_solution_cpp_src
 from .test_src import generate_test_src

--- a/internal/python/lib/generate_test_src/generators/solution_cpp_src.py
+++ b/internal/python/lib/generate_test_src/generators/solution_cpp_src.py
@@ -1,0 +1,36 @@
+import os
+
+
+def generate_solution_cpp_src(source_dir: str, out_dir: str, config: any):
+    with open(os.path.join(out_dir, "solution_cpp.cpp"), "w") as output:
+        if "cpp" not in config["solutions"]:
+            return
+
+        cfg = config["solutions"]["cpp"]
+
+        if cfg is not None and "includes" in cfg:
+            for include in cfg["includes"]:
+                output.write("#include <%s>\n" % include)
+            output.write("\nusing namespace std;\n\n")
+
+        with open(os.path.join(source_dir, "solution.cpp"), "r") as source:
+            for line in source.readlines():
+                output.write(line)
+
+        output.write("\n%s solution_cpp(" % config["types"]["output"])
+        output.write(
+            ", ".join(
+                [("%s %s" % (t, v)) for v, t in config["types"]["inputs"].items()]
+            )
+        )
+        output.write(") {\n")
+
+        output.write("  auto output = Solution().%s(" % cfg["function"])
+        output.write(", ".join(config["types"]["inputs"]))
+        output.write(");\n")
+
+        output.write(
+            "  return %s;\n" % (cfg["output"] if "output" in cfg else "output")
+        )
+
+        output.write("}\n")

--- a/internal/python/lib/generate_test_src/generators/test_src.py
+++ b/internal/python/lib/generate_test_src/generators/test_src.py
@@ -1,0 +1,59 @@
+import os
+
+
+def generate_test_src(out_dir: str, config: any):
+    with open(os.path.join(out_dir, "test.cpp"), "w") as output:
+        output.write("#include <catch2/catch_test_macros.hpp>\n")
+        output.write("#include <string>\n")
+        output.write("#include <vector>\n")
+
+        output.write("\n")
+        for lang in config["solutions"]:
+            output.write("%s solution_%s(" % (config["types"]["output"], lang))
+            output.write(
+                ", ".join(
+                    [("%s %s" % (t, v)) for v, t in config["types"]["inputs"].items()]
+                )
+            )
+            output.write(");\n")
+
+        output.write("\nstruct TestCase {\n")
+        output.write("  struct Inputs {\n")
+        for v, t in config["types"]["inputs"].items():
+            output.write("    %s %s;\n" % (t, v))
+        output.write("  };\n\n")
+        output.write("  std::string name;\n")
+        output.write("  Inputs inputs;\n")
+        output.write("  %s output;\n" % config["types"]["output"])
+        output.write("};\n")
+
+        def dump(data):
+            import json
+
+            s = json.dumps(data)
+            return s.replace("[", "{").replace("]", "}")
+
+        output.write("\nconst std::vector<TestCase> test_cases = {\n")
+        for name in config["test_cases"]:
+            cfg = config["test_cases"][name]
+            output.write("  {\n")
+            output.write('    .name = "%s",\n' % name)
+            output.write("    .inputs = {\n")
+            for var, val in cfg["inputs"].items():
+                output.write("      .%s = %s,\n" % (var, dump(val)))
+            output.write("    },\n")
+            output.write("    .output = %s\n" % dump(cfg["output"]))
+            output.write("  },\n")
+        output.write("};\n")
+
+        for lang in config["solutions"]:
+            output.write('\nTEST_CASE("%s (%s)") {\n' % (config["name"], lang))
+            output.write("  for (const auto& [name, inputs, output] : test_cases) {\n")
+
+            inputs = ", ".join(config["types"]["inputs"])
+            output.write("    const auto [%s] = inputs;\n" % inputs)
+            output.write("    CAPTURE(name, %s);\n" % inputs)
+            output.write("    CHECK(solution_%s(%s) == output);\n" % (lang, inputs))
+
+            output.write("  }\n")
+            output.write("}\n")


### PR DESCRIPTION
This pull request reorganizes the script for generating test source files by separating the lines into individual files under the `generators` directory. The decision to keep the lines as smaller functions was considered challenging, and it implies major changes in how the test source file generator is generated. While this pull request doesn't directly close #94, it is a step towards addressing it. Further changes to break down functions into smaller units will be made incrementally for each function.