### PR TITLE
Solve Problem 1743. Restore the Array From Adjacent Pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1535. Find the Winner of an Array Game](https://leetcode.com/problems/find-the-winner-of-an-array-game) | Medium | [C++](./problems/1535/solution.cpp) |
 | [1658. Minimum Operations to Reduce X to Zero](https://leetcode.com/problems/minimum-operations-to-reduce-x-to-zero) | Medium | [C++](./problems/1658/solution.cpp) |
 | [1759. Count Number of Homogenous Substrings](https://leetcode.com/problems/count-number-of-homogenous-substrings) | Medium | [C](./problems/1759/c/solution.c) [C++](./problems/1759/solution.cpp) |
+| [1743. Restore the Array From Adjacent Pairs](https://leetcode.com/problems/restore-the-array-from-adjacent-pairs) | Medium | [C++](./problems/1743/solution.cpp) |
 | [1793. Maximum Score of a Good Subarray](https://leetcode.com/problems/maximum-score-of-a-good-subarray) | Hard | [C](./problems/1793/c/solution.c) [C++](./problems/1793/solution.cpp) |
 | [1921. Eliminate Maximum Number of Monsters](https://leetcode.com/problems/eliminate-maximum-number-of-monsters) | Medium | [C++](./problems/1921/solution.cpp) |
 | [2009. Minimum Number of Operations to Make Array Continuous](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-continuous) | Hard | [C++](./problems/2009/solution.cpp) |

--- a/problems/1743/CMakeLists.txt
+++ b/problems/1743/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/problems/1743/solution.cpp
+++ b/problems/1743/solution.cpp
@@ -1,7 +1,33 @@
 class Solution {
  public:
   vector<int> restoreArray(vector<vector<int>>& adjacentPairs) {
-    (void)adjacentPairs;
-    return {};
+    unordered_map<int, list<int>> adjacents;
+    for (const auto& pair : adjacentPairs) {
+      adjacents[pair[0]].push_back(pair[1]);
+      adjacents[pair[1]].push_back(pair[0]);
+    }
+
+    const auto begin = find_if(adjacents.begin(), adjacents.end(), [](const auto& pair) {
+      return pair.second.size() == 1;
+    });
+
+    vector<int> res(adjacentPairs.size() + 1);
+    res[0] = begin->first;
+
+    int prev = begin->first;
+    int current = begin->second.front();
+
+    for (size_t i = 1; i < res.size() - 1; ++i) {
+      for (auto adjacent : adjacents[current]) {
+        if (adjacent == prev) continue;
+        res[i] = prev = current;
+        current = adjacent;
+        break;
+      }
+    }
+
+    res[res.size() - 1] = current;
+
+    return res;
   }
 };

--- a/problems/1743/solution.cpp
+++ b/problems/1743/solution.cpp
@@ -1,0 +1,7 @@
+class Solution {
+ public:
+  vector<int> restoreArray(vector<vector<int>>& adjacentPairs) {
+    (void)adjacentPairs;
+    return {};
+  }
+};

--- a/problems/1743/solution.cpp
+++ b/problems/1743/solution.cpp
@@ -1,22 +1,30 @@
+// The solution can be done as follows:
+// - Convert a vector of pairs to a hash map for easy access to adjacent values.
+// - Find the beginning (or the end) of the array's value. This can be done by searching for a value in the hash map that has only one adjacent value.
+// - Recursively construct the array by putting adjacent values starting from the beginning value.
+
 class Solution {
  public:
   vector<int> restoreArray(vector<vector<int>>& adjacentPairs) {
+    // Convert to a hash map. Both values of the pair will be associated with different keys.
     unordered_map<int, list<int>> adjacents;
     for (const auto& pair : adjacentPairs) {
       adjacents[pair[0]].push_back(pair[1]);
       adjacents[pair[1]].push_back(pair[0]);
     }
 
+    // Find the beginning (or the end) of the array's value.
     const auto begin = find_if(adjacents.begin(), adjacents.end(), [](const auto& pair) {
       return pair.second.size() == 1;
     });
 
+    // Construct the array starting with the beginning value.
     vector<int> res(adjacentPairs.size() + 1);
     res[0] = begin->first;
 
+    // Repeatedly add adjacent values starting from the beginning value.
     int prev = begin->first;
     int current = begin->second.front();
-
     for (size_t i = 1; i < res.size() - 1; ++i) {
       for (auto adjacent : adjacents[current]) {
         if (adjacent == prev) continue;
@@ -26,6 +34,7 @@ class Solution {
       }
     }
 
+    // Add the last value.
     res[res.size() - 1] = current;
 
     return res;

--- a/problems/1743/test.yaml
+++ b/problems/1743/test.yaml
@@ -14,14 +14,14 @@ test_cases:
   example_1:
     inputs:
       adjacentPairs: [[2, 1], [3, 4], [3, 2]]
-    output: [1, 2, 3, 4]
+    output: [4, 3, 2, 1]
 
   example_2:
     inputs:
       adjacentPairs: [[4, -2], [1, 4], [-3, 1]]
-    output: [-2, 4, 1, -3]
+    output: [-3, 1, 4, -2]
 
   example_3:
     inputs:
       adjacentPairs: [[100000, -100000]]
-    output: [100000, -100000]
+    output: [-100000, 100000]

--- a/problems/1743/test.yaml
+++ b/problems/1743/test.yaml
@@ -1,0 +1,27 @@
+name: 1743. Restore the Array From Adjacent Pairs
+
+types:
+  inputs:
+    adjacentPairs: std::vector<std::vector<int>>
+  output: std::vector<int>
+
+solutions:
+  cpp:
+    function: restoreArray
+    includes: [vector]
+
+test_cases:
+  example_1:
+    inputs:
+      adjacentPairs: [[2, 1], [3, 4], [3, 2]]
+    output: [1, 2, 3, 4]
+
+  example_2:
+    inputs:
+      adjacentPairs: [[4, -2], [1, 4], [-3, 1]]
+    output: [-2, 4, 1, -3]
+
+  example_3:
+    inputs:
+      adjacentPairs: [[100000, -100000]]
+    output: [100000, -100000]

--- a/problems/1743/test.yaml
+++ b/problems/1743/test.yaml
@@ -8,7 +8,7 @@ types:
 solutions:
   cpp:
     function: restoreArray
-    includes: [vector]
+    includes: [algorithm, list, unordered_map, vector]
 
 test_cases:
   example_1:


### PR DESCRIPTION
This pull request solves problem [1743. Restore the Array From Adjacent Pairs](https://leetcode.com/problems/restore-the-array-from-adjacent-pairs) in C++ language. It closes #154.

The solution could be done as follows:
- Convert a vector of pairs to a hash map for easy access to adjacent values.
- Find the beginning (or the end) of the array's value. This can be done by searching for a value in the hash map that has only one adjacent value.
- Recursively construct the array by putting adjacent values starting from the beginning value.