### PR TITLE
Use CheckWarning.cmake

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -15,3 +15,10 @@ CPMDeclarePackage(Catch2
   SYSTEM YES
   EXCLUDE_FROM_ALL YES
 )
+# CheckWarning.cmake
+CPMDeclarePackage(CheckWarning.cmake
+  VERSION 1.0.0
+  GITHUB_REPOSITORY threeal/CheckWarning.cmake
+  SYSTEM YES
+  EXCLUDE_FROM_ALL YES
+)

--- a/package-lock
+++ b/package-lock
@@ -17,7 +17,7 @@ CPMDeclarePackage(Catch2
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 1.0.0
+  VERSION 1.1.0
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -4,7 +4,9 @@ endmacro()
 
 function(target_set_cpp_standard target)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
-  target_compile_options(${target} PRIVATE -Werror -Wall -Wextra -Wpedantic)
+
+  cpmgetpackage(CheckWarning.cmake)
+  target_check_warning(${target})
 endfunction()
 
 macro(add_c_solution target)


### PR DESCRIPTION
This pull request implements [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) to streamline compiler warning checks, replacing the previous manual implementation that relied on specifying `target_compile_options`. It closes #167.