### PR TITLE
Use Ninja in the Workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,7 @@ jobs:
         uses: threeal/cmake-action@v1.3.0
         with:
           run-build: true
+          generator: Ninja
 
       - name: Check format
         run: |


### PR DESCRIPTION
This pull request modifies the CI workflow to use [Ninja](https://ninja-build.org/) as the build system generator. It closes #233.