### PR TITLE
Remove Includes Option From Test Configuration

### DIFF
--- a/internal/python/lib/generate_test_src/generators/solution_cpp_src.py
+++ b/internal/python/lib/generate_test_src/generators/solution_cpp_src.py
@@ -8,11 +8,6 @@ def generate_solution_cpp_src(source_dir: str, out_dir: str, config: any):
 
         cfg = config["solutions"]["cpp"]
 
-        if cfg is not None and "includes" in cfg:
-            for include in cfg["includes"]:
-                output.write("#include <%s>\n" % include)
-            output.write("\nusing namespace std;\n\n")
-
         with open(os.path.join(source_dir, "solution.cpp"), "r") as source:
             for line in source.readlines():
                 output.write(line)

--- a/problems/0001/solution.cpp
+++ b/problems/0001/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  vector<int> twoSum(vector<int>& nums, int target) {
+  std::vector<int> twoSum(std::vector<int>& nums, int target) {
     const int n = nums.size();
     for (int i = 0; i < n; ++i) {
       for (int j = i + 1; j < n; ++j) {

--- a/problems/0001/test.yaml
+++ b/problems/0001/test.yaml
@@ -10,7 +10,6 @@ solutions:
   c:
   cpp:
     function: twoSum
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/0003/solution.cpp
+++ b/problems/0003/solution.cpp
@@ -1,11 +1,14 @@
+#include <string>
+#include <unordered_set>
+
 class Solution {
  public:
-  int lengthOfLongestSubstring(string s) {
+  int lengthOfLongestSubstring(std::string s) {
     return longest(s.c_str(), s.size());
   }
 
   int longest(const char* str, int n) {
-    unordered_set<char> cs;
+    std::unordered_set<char> cs;
     int i = 0;
     while (i < n) {
       if (cs.contains(str[i])) break;
@@ -15,6 +18,6 @@ class Solution {
     if (n <= 1) return i;
     auto j = longest(str + 1, n - 1);
 
-    return max(i, j);
+    return std::max(i, j);
   }
 };

--- a/problems/0003/test.yaml
+++ b/problems/0003/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: lengthOfLongestSubstring
-    includes: [string, unordered_set]
 
 test_cases:
   example_1:

--- a/problems/0004/solution.cpp
+++ b/problems/0004/solution.cpp
@@ -1,6 +1,9 @@
+#include <stack>
+#include <vector>
+
 class Solution {
  public:
-  double findMedianSortedArrays(vector<int>& a, vector<int>& b) {
+  double findMedianSortedArrays(std::vector<int>& a, std::vector<int>& b) {
     const auto ae = a.end();
     const auto be = b.end();
 
@@ -18,7 +21,7 @@ class Solution {
       return is_even ? (a[n] + a[n - 1]) / 2.0 : a[n];
     }
 
-    stack<int> s;
+    std::stack<int> s;
     while (n >= 0) {
       if (*ai < *bi) {
         s.push(*ai);

--- a/problems/0004/test.yaml
+++ b/problems/0004/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: findMedianSortedArrays
-    includes: [stack, vector]
 
 test_cases:
   odd_total_size:

--- a/problems/0005/solution.cpp
+++ b/problems/0005/solution.cpp
@@ -1,12 +1,15 @@
+#include <functional>
+#include <string>
+
 class Solution {
  public:
-  string longestPalindrome(string s) {
+  std::string longestPalindrome(std::string s) {
     const int n = s.size();
 
     int res_a = 0;
     int res_n = 1;
 
-    const function<void(int, int)> fn = [&](int a, int b) {
+    const std::function<void(int, int)> fn = [&](int a, int b) {
       if (s[a] != s[b]) return;
       while (a >= 0 && b < n) {
         if (s[a] != s[b]) break;

--- a/problems/0005/test.yaml
+++ b/problems/0005/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: longestPalindrome
-    includes: [functional, string]
 
 test_cases:
   example_1:

--- a/problems/0006/solution.cpp
+++ b/problems/0006/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  string convert(string s, int numRows) {
+  std::string convert(std::string s, int numRows) {
     if (numRows == 1) return s;
 
     auto res = s;

--- a/problems/0006/test.yaml
+++ b/problems/0006/test.yaml
@@ -10,7 +10,6 @@ solutions:
   c:
   cpp:
     function: convert
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0008/solution.cpp
+++ b/problems/0008/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  int myAtoi(string s) {
+  int myAtoi(std::string s) {
     const int n = s.size();
 
     int i;

--- a/problems/0008/test.yaml
+++ b/problems/0008/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: myAtoi
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0009/solution.cpp
+++ b/problems/0009/solution.cpp
@@ -6,7 +6,7 @@ class Solution {
     if (x < 0) return false;
 
     std::list<int> list;
-    size_t n = 0;
+    std::size_t n = 0;
     while (x > 0) {
       list.push_back(x % 10);
       x = x / 10;
@@ -16,7 +16,7 @@ class Solution {
     n = n / 2;
     auto a = list.begin();
     auto b = --list.end();
-    for (size_t i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
       if (*a != *b) return false;
       ++a;
       --b;

--- a/problems/0009/solution.cpp
+++ b/problems/0009/solution.cpp
@@ -1,3 +1,5 @@
+#include <list>
+
 class Solution {
  public:
   bool isPalindrome(int x) {

--- a/problems/0009/test.yaml
+++ b/problems/0009/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: isPalindrome
-    includes: [list]
 
 test_cases:
   example_1:

--- a/problems/0011/solution.cpp
+++ b/problems/0011/solution.cpp
@@ -1,12 +1,14 @@
+#include <vector>
+
 class Solution {
  public:
-  int maxArea(vector<int>& height) {
+  int maxArea(std::vector<int>& height) {
     int left = 0;
     int right = height.size() - 1;
 
     int leftHeight = height[left];
     int rightHeight = height[right];
-    int max = min(leftHeight, rightHeight) * (right - left);
+    int max = std::min(leftHeight, rightHeight) * (right - left);
 
     while (left < right) {
       if (leftHeight <= rightHeight) {
@@ -14,7 +16,7 @@ class Solution {
           ++left;
           if (height[left] <= leftHeight) continue;
           leftHeight = height[left];
-          int newMax = min(leftHeight, rightHeight) * (right - left);
+          int newMax = std::min(leftHeight, rightHeight) * (right - left);
           if (newMax > max) max = newMax;
           if (leftHeight > rightHeight) break;
         }
@@ -23,7 +25,7 @@ class Solution {
           --right;
           if (height[right] <= rightHeight) continue;
           rightHeight = height[right];
-          int newMax = min(leftHeight, rightHeight) * (right - left);
+          int newMax = std::min(leftHeight, rightHeight) * (right - left);
           if (newMax > max) max = newMax;
           if (rightHeight >= leftHeight) break;
         }

--- a/problems/0011/test.yaml
+++ b/problems/0011/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: maxArea
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/0015/solution.cpp
+++ b/problems/0015/solution.cpp
@@ -1,12 +1,16 @@
+#include <algorithm>
+#include <map>
+#include <vector>
+
 class Solution {
  public:
-  vector<vector<int>> threeSum(vector<int>& nums) {
-    map<int, int, greater<int>> counts;
+  std::vector<std::vector<int>> threeSum(std::vector<int>& nums) {
+    std::map<int, int, std::greater<int>> counts;
     for (const auto num : nums) {
       ++counts[num];
     }
 
-    vector<vector<int>> result;
+    std::vector<std::vector<int>> result;
     const auto counts_end = counts.end();
     for (auto ai = counts.begin(); ai != counts_end; ++ai) {
       const auto a = ai->first;

--- a/problems/0015/test.yaml
+++ b/problems/0015/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: threeSum
-    includes: [algorithm, map, vector]
 
 test_cases:
   example_1:

--- a/problems/0017/solution.cpp
+++ b/problems/0017/solution.cpp
@@ -1,6 +1,9 @@
+#include <string>
+#include <vector>
+
 class Solution {
  public:
-  vector<string> letterCombinations(string digits) {
+  std::vector<std::string> letterCombinations(std::string digits) {
     const auto n = digits.size();
     if (n == 0) return {};
 

--- a/problems/0017/solution.cpp
+++ b/problems/0017/solution.cpp
@@ -8,10 +8,10 @@ class Solution {
     if (n == 0) return {};
 
     // Calculate repeat for each digits.
-    std::vector<size_t> repeats(n, 1);
-    for (size_t i = 0; i < n; ++i) {
+    std::vector<std::size_t> repeats(n, 1);
+    for (std::size_t i = 0; i < n; ++i) {
       repeats[i] = repeat_of(digits[i]);
-      for (size_t j = 0; j < i; ++j) {
+      for (std::size_t j = 0; j < i; ++j) {
         repeats[j] *= repeats[i];
       }
     }
@@ -22,7 +22,7 @@ class Solution {
       result.resize(n);
     }
 
-    for (size_t i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
       switch (digits[i]) {
         case '2':
           repeat_digit(results, "abc", repeats[i], i);
@@ -61,7 +61,7 @@ class Solution {
     return results;
   }
 
-  size_t repeat_of(char digit) {
+  std::size_t repeat_of(char digit) {
     switch (digit) {
       case '7':
       case '9':
@@ -70,14 +70,14 @@ class Solution {
     return 3;
   }
 
-  void repeat_digit(std::vector<std::string>& results, const std::string& chars, size_t repeat, size_t i) {
+  void repeat_digit(std::vector<std::string>& results, const std::string& chars, std::size_t repeat, std::size_t i) {
     repeat /= chars.size();
 
-    size_t j = 0;
+    std::size_t j = 0;
     const auto n = results.size();
     while (j < n) {
       for (const auto c : chars) {
-        for (size_t k = 0; k < repeat; ++k) {
+        for (std::size_t k = 0; k < repeat; ++k) {
           results[j + k][i] = c;
         }
         j += repeat;

--- a/problems/0017/test.yaml
+++ b/problems/0017/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: letterCombinations
-    includes: [string, vector]
 
 test_cases:
   example_1:

--- a/problems/0026/solution.cpp
+++ b/problems/0026/solution.cpp
@@ -1,7 +1,10 @@
+#include <unordered_set>
+#include <vector>
+
 class Solution {
  public:
-  int removeDuplicates(vector<int>& nums) {
-    unordered_set<int> s;
+  int removeDuplicates(std::vector<int>& nums) {
+    std::unordered_set<int> s;
     int k = 0;
     int n = nums.size();
     for (int i = 0; i < n; ++i) {

--- a/problems/0026/test.yaml
+++ b/problems/0026/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: removeDuplicates
-    includes: [unordered_set, vector]
     output: std::vector(nums.begin(), nums.begin() + output)
 
 test_cases:

--- a/problems/0027/solution.cpp
+++ b/problems/0027/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int removeElement(vector<int>& nums, int val) {
+  int removeElement(std::vector<int>& nums, int val) {
     int k = -1;
     int n = nums.size();
     for (int i = 0; i < n; ++i) {

--- a/problems/0027/test.yaml
+++ b/problems/0027/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: removeElement
-    includes: [vector]
     output: std::vector(nums.begin(), nums.begin() + output)
 
 test_cases:

--- a/problems/0028/solution.cpp
+++ b/problems/0028/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  int strStr(string haystack, string needle) {
+  int strStr(std::string haystack, std::string needle) {
     int hn = haystack.size();
     int nn = needle.size();
     for (int hi = 0; hi <= hn - nn; ++hi) {

--- a/problems/0028/test.yaml
+++ b/problems/0028/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: strStr
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0034/solution.cpp
+++ b/problems/0034/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  vector<int> searchRange(vector<int>& nums, int target) {
+  std::vector<int> searchRange(std::vector<int>& nums, int target) {
     const int n = nums.size();
 
     int a = 0;

--- a/problems/0034/test.yaml
+++ b/problems/0034/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: searchRange
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/0035/solution.cpp
+++ b/problems/0035/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int searchInsert(vector<int>& nums, int target) {
+  int searchInsert(std::vector<int>& nums, int target) {
     int left = 0;
     int right = nums.size() - 1;
 

--- a/problems/0035/test.yaml
+++ b/problems/0035/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: searchInsert
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/0058/solution.cpp
+++ b/problems/0058/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  int lengthOfLastWord(string s) {
+  int lengthOfLastWord(std::string s) {
     const int n = s.size();
     int b = n - 1;
     while (b >= 0) {

--- a/problems/0058/test.yaml
+++ b/problems/0058/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: lengthOfLastWord
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0066/solution.cpp
+++ b/problems/0066/solution.cpp
@@ -5,7 +5,7 @@ class Solution {
  public:
   std::vector<int> plusOne(std::vector<int>& digits) {
     std::reverse(digits.begin(), digits.end());
-    size_t i = 0;
+    std::size_t i = 0;
     ++digits[i];
     while (digits[i] >= 10) {
       ++i;

--- a/problems/0066/solution.cpp
+++ b/problems/0066/solution.cpp
@@ -1,7 +1,10 @@
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> plusOne(vector<int>& digits) {
-    reverse(digits.begin(), digits.end());
+  std::vector<int> plusOne(std::vector<int>& digits) {
+    std::reverse(digits.begin(), digits.end());
     size_t i = 0;
     ++digits[i];
     while (digits[i] >= 10) {
@@ -13,7 +16,7 @@ class Solution {
       }
       digits[i - 1] %= 10;
     }
-    reverse(digits.begin(), digits.end());
+    std::reverse(digits.begin(), digits.end());
     return digits;
   }
 };

--- a/problems/0066/test.yaml
+++ b/problems/0066/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: plusOne
-    includes: [algorithm, vector]
 
 test_cases:
   example_1:

--- a/problems/0119/solution.cpp
+++ b/problems/0119/solution.cpp
@@ -1,7 +1,10 @@
+#include <functional>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> getRow(int rowIndex) {
-    auto cache = vector(rowIndex + 1, vector<int>());
+  std::vector<int> getRow(int rowIndex) {
+    auto cache = std::vector(rowIndex + 1, std::vector<int>());
     for (int i = 0; i <= rowIndex; ++i) {
       cache[i].resize(i + 1);
     }
@@ -15,7 +18,7 @@ class Solution {
       return cache[row][index];
     };
 
-    vector<int> arr(rowIndex + 1);
+    std::vector<int> arr(rowIndex + 1);
     for (int i = 0; i <= rowIndex; ++i) {
       arr[i] = fn(rowIndex, i);
     }

--- a/problems/0119/test.yaml
+++ b/problems/0119/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: getRow
-    includes: [functional, vector]
 
 test_cases:
   example_1:

--- a/problems/0229/solution.cpp
+++ b/problems/0229/solution.cpp
@@ -1,12 +1,15 @@
+#include <unordered_map>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> majorityElement(vector<int>& nums) {
-    unordered_map<int, int> counts;
+  std::vector<int> majorityElement(std::vector<int>& nums) {
+    std::unordered_map<int, int> counts;
     for (auto num : nums) {
       ++counts[num];
     }
 
-    vector<int> result;
+    std::vector<int> result;
     const int threshold = nums.size() / 3;
     for (auto [num, count] : counts) {
       if (count > threshold) result.push_back(num);

--- a/problems/0229/test.yaml
+++ b/problems/0229/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: majorityElement
-    includes: [algorithm, unordered_map, vector]
     output: "[&]{ sort(output.begin(), output.end()); return output; }()"
 
 test_cases:

--- a/problems/0316/solution.cpp
+++ b/problems/0316/solution.cpp
@@ -6,7 +6,7 @@
 class Solution {
  public:
   std::string removeDuplicateLetters(std::string s) {
-    std::unordered_map<char, size_t> counts;
+    std::unordered_map<char, std::size_t> counts;
     for (const auto c : s) {
       ++counts[c];
     }

--- a/problems/0316/solution.cpp
+++ b/problems/0316/solution.cpp
@@ -1,13 +1,18 @@
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
 class Solution {
  public:
-  string removeDuplicateLetters(string s) {
-    unordered_map<char, size_t> counts;
+  std::string removeDuplicateLetters(std::string s) {
+    std::unordered_map<char, size_t> counts;
     for (const auto c : s) {
       ++counts[c];
     }
 
-    unordered_set<char> existed;
-    stack<char> orders;
+    std::unordered_set<char> existed;
+    std::stack<char> orders;
 
     for (const auto c : s) {
       --counts[c];
@@ -22,7 +27,7 @@ class Solution {
       existed.insert(c);
     }
 
-    string res;
+    std::string res;
     while (!orders.empty()) {
       res = orders.top() + res;
       orders.pop();

--- a/problems/0316/test.yaml
+++ b/problems/0316/test.yaml
@@ -8,11 +8,6 @@ types:
 solutions:
   cpp:
     function: removeDuplicateLetters
-    includes:
-      - stack
-      - string
-      - unordered_map
-      - unordered_set
 
 test_cases:
   example_1:

--- a/problems/0343/solution.cpp
+++ b/problems/0343/solution.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 class Solution {
  public:
   int integerBreak(int n) {
@@ -6,7 +8,7 @@ class Solution {
       const int div = n / i;
       const int mod = n % i;
 
-      vector<int> nums(i, div);
+      std::vector<int> nums(i, div);
       if (mod > 0) {
         for (int j = 0; j < mod; ++j) {
           ++nums[j];
@@ -23,7 +25,7 @@ class Solution {
     return res;
   }
 
-  int multiplies(const vector<int>& nums) {
+  int multiplies(const std::vector<int>& nums) {
     int total = 1;
     for (int num : nums) {
       total *= num;

--- a/problems/0343/test.yaml
+++ b/problems/0343/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: integerBreak
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/0387/solution.cpp
+++ b/problems/0387/solution.cpp
@@ -1,8 +1,12 @@
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
 class Solution {
  public:
-  int firstUniqChar(string s) {
-    unordered_set<char> duplicates;
-    unordered_map<char, int> uniques;
+  int firstUniqChar(std::string s) {
+    std::unordered_set<char> duplicates;
+    std::unordered_map<char, int> uniques;
 
     const int n = s.size();
     for (int i = 0; i < n; ++i) {

--- a/problems/0387/test.yaml
+++ b/problems/0387/test.yaml
@@ -8,10 +8,6 @@ types:
 solutions:
   cpp:
     function: firstUniqChar
-    includes:
-      - string
-      - unordered_map
-      - unordered_set
 
 test_cases:
   example_1:

--- a/problems/0389/solution.cpp
+++ b/problems/0389/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  char findTheDifference(string s, string t) {
+  char findTheDifference(std::string s, std::string t) {
     char maps[26];
     for (int i = 0; i < 26; ++i) {
       maps[i] = 0;

--- a/problems/0389/test.yaml
+++ b/problems/0389/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: findTheDifference
-    includes: [string]
     output: "{output}"
 
 test_cases:

--- a/problems/0392/solution.cpp
+++ b/problems/0392/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  bool isSubsequence(string s, string t) {
+  bool isSubsequence(std::string s, std::string t) {
     auto si = s.begin();
     const auto se = s.end();
     if (si == se) return true;

--- a/problems/0392/test.yaml
+++ b/problems/0392/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: isSubsequence
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0458/solution.cpp
+++ b/problems/0458/solution.cpp
@@ -1,6 +1,8 @@
+#include <ctgmath>
+
 class Solution {
  public:
   int poorPigs(int buckets, int minutesToDie, int minutesToTest) {
-    return ceil(log2(buckets) / log2(minutesToTest / minutesToDie + 1));
+    return std::ceil(std::log2(buckets) / std::log2(minutesToTest / minutesToDie + 1));
   }
 };

--- a/problems/0458/test.yaml
+++ b/problems/0458/test.yaml
@@ -11,7 +11,6 @@ solutions:
   c:
   cpp:
     function: poorPigs
-    includes: [ctgmath]
 
 test_cases:
   example_1:

--- a/problems/0557/solution.cpp
+++ b/problems/0557/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  string reverseWords(string s) {
+  std::string reverseWords(std::string s) {
     const int n = s.size();
     int a = 0;
     for (int i = 0; i < n; ++i) {
@@ -15,7 +17,7 @@ class Solution {
     return s;
   }
 
-  void swap(string& s, int a, int b) {
+  void swap(std::string& s, int a, int b) {
     while (b > a) {
       auto tmp = s[a];
       s[a] = s[b];

--- a/problems/0557/test.yaml
+++ b/problems/0557/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: reverseWords
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0746/solution.cpp
+++ b/problems/0746/solution.cpp
@@ -1,17 +1,21 @@
+#include <algorithm>
+#include <functional>
+#include <vector>
+
 class Solution {
  public:
-  int minCostClimbingStairs(vector<int>& cost) {
+  int minCostClimbingStairs(std::vector<int>& cost) {
     const auto n = cost.size();
-    vector<int> cache(n, -1);
+    std::vector<int> cache(n, -1);
 
-    function<int(size_t)> fn = [&](size_t i) {
+    std::function<int(size_t)> fn = [&](size_t i) {
       if (i >= n) return 0;
       if (cache[i] < 0) {
-        cache[i] = cost[i] + min(fn(i + 1), fn(i + 2));
+        cache[i] = cost[i] + std::min(fn(i + 1), fn(i + 2));
       }
       return cache[i];
     };
 
-    return min(fn(0), fn(1));
+    return std::min(fn(0), fn(1));
   }
 };

--- a/problems/0746/solution.cpp
+++ b/problems/0746/solution.cpp
@@ -8,7 +8,7 @@ class Solution {
     const auto n = cost.size();
     std::vector<int> cache(n, -1);
 
-    std::function<int(size_t)> fn = [&](size_t i) {
+    std::function<int(std::size_t)> fn = [&](std::size_t i) {
       if (i >= n) return 0;
       if (cache[i] < 0) {
         cache[i] = cost[i] + std::min(fn(i + 1), fn(i + 2));

--- a/problems/0746/test.yaml
+++ b/problems/0746/test.yaml
@@ -8,10 +8,6 @@ types:
 solutions:
   cpp:
     function: minCostClimbingStairs
-    includes:
-      - algorithm
-      - functional
-      - vector
 
 test_cases:
   example_1:

--- a/problems/0815/solution.cpp
+++ b/problems/0815/solution.cpp
@@ -4,15 +4,20 @@
 // - If the target route contains any of the current buses, return the required number of buses.
 // - Else, get all buses that are connected with the current buses and repeat the previous step.
 
+#include <list>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
 class Solution {
  public:
-  int numBusesToDestination(vector<vector<int>>& routes, int source, int target) {
+  int numBusesToDestination(std::vector<std::vector<int>>& routes, int source, int target) {
     // Bus is not required if the source and target routes are the same.
     if (source == target) return 0;
 
     // Create a hash table that maps buses to each route.
     const int busCount = routes.size();
-    unordered_map<int, unordered_set<int>> routesBuses;
+    std::unordered_map<int, std::unordered_set<int>> routesBuses;
     for (int bus = 0; bus < busCount; ++bus) {
       for (const auto route : routes[bus]) {
         routesBuses[route].insert(bus);
@@ -20,12 +25,12 @@ class Solution {
     }
 
     // Mark the source route as visited.
-    unordered_set<int> visitedRoutes;
+    std::unordered_set<int> visitedRoutes;
     visitedRoutes.insert(source);
 
     // Get all buses from the source route.
-    list<int> busesToVisit;
-    unordered_set<int> visitedBuses;
+    std::list<int> busesToVisit;
+    std::unordered_set<int> visitedBuses;
     for (const auto bus : routesBuses[source]) {
       busesToVisit.push_back(bus);
       visitedBuses.insert(bus);
@@ -34,7 +39,7 @@ class Solution {
     // Repeat until there is no more bus to visit.
     int count = 1;
     while (!busesToVisit.empty()) {
-      list<int> nextBusesToVisit;
+      std::list<int> nextBusesToVisit;
       for (const auto busToVisit : busesToVisit) {
         // If the current bus has the target route, return the required number of buses to visit.
         if (routesBuses[target].contains(busToVisit)) return count;

--- a/problems/0815/test.yaml
+++ b/problems/0815/test.yaml
@@ -10,11 +10,6 @@ types:
 solutions:
   cpp:
     function: numBusesToDestination
-    includes:
-      - list
-      - unordered_map
-      - unordered_set
-      - vector
 
 test_cases:
   example_1:

--- a/problems/0823/solution.cpp
+++ b/problems/0823/solution.cpp
@@ -14,12 +14,12 @@ class Solution {
 
     // Iterate from lower values to higher values.
     std::sort(arr.begin(), arr.end());
-    for (size_t i = 0; i < arr.size(); ++i) {
+    for (std::size_t i = 0; i < arr.size(); ++i) {
       // A value can be its own node.
       int comb = 1;
 
       // Find values that could serve as child nodes.
-      for (size_t j = 0; j < i; ++j) {
+      for (std::size_t j = 0; j < i; ++j) {
         if (arr[i] % arr[j] > 0) continue;
         const auto it = comb_of.find(arr[i] / arr[j]);
         if (it == comb_of.end()) continue;

--- a/problems/0823/solution.cpp
+++ b/problems/0823/solution.cpp
@@ -1,15 +1,19 @@
+#include <algorithm>
+#include <unordered_map>
+#include <vector>
+
 const int mod = 1'000'000'007;
 
 class Solution {
  public:
-  int numFactoredBinaryTrees(vector<int>& arr) {
+  int numFactoredBinaryTrees(std::vector<int>& arr) {
     int res = 0;
 
     // Container to track the number of combinations for each value.
-    unordered_map<int, int> comb_of;
+    std::unordered_map<int, int> comb_of;
 
     // Iterate from lower values to higher values.
-    sort(arr.begin(), arr.end());
+    std::sort(arr.begin(), arr.end());
     for (size_t i = 0; i < arr.size(); ++i) {
       // A value can be its own node.
       int comb = 1;

--- a/problems/0823/test.yaml
+++ b/problems/0823/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: numFactoredBinaryTrees
-    includes: [algorithm, unordered_map, vector]
 
 test_cases:
   example_1:

--- a/problems/0844/solution.cpp
+++ b/problems/0844/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  bool backspaceCompare(string s, string t) {
+  bool backspaceCompare(std::string s, std::string t) {
     auto ss = s.rbegin();
     auto tt = t.rbegin();
 
@@ -27,7 +29,7 @@ class Solution {
   }
 
   // This function will increment the iterator as long as it still contains the backspace character (`#`).
-  void shift_backspace(string::reverse_iterator& it, string::reverse_iterator end) {
+  void shift_backspace(std::string::reverse_iterator& it, std::string::reverse_iterator end) {
     int skip = 0;
     while (it != end && *it == '#') {
       ++skip;

--- a/problems/0844/test.yaml
+++ b/problems/0844/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: backspaceCompare
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0880/solution.cpp
+++ b/problems/0880/solution.cpp
@@ -1,11 +1,13 @@
+#include <string>
+
 class Solution {
  private:
-  string str;
+  std::string str;
 
  public:
-  string decodeAtIndex(string s, int k) {
+  std::string decodeAtIndex(std::string s, int k) {
     str = s;
-    return string() + decode(k - 1);
+    return std::string() + decode(k - 1);
   }
 
   char decode(uint64_t k) {

--- a/problems/0880/test.yaml
+++ b/problems/0880/test.yaml
@@ -10,7 +10,6 @@ solutions:
   c:
   cpp:
     function: decodeAtIndex
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/0905/solution.cpp
+++ b/problems/0905/solution.cpp
@@ -1,7 +1,10 @@
+#include <list>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> sortArrayByParity(vector<int>& nums) {
-    list<int> odd, even;
+  std::vector<int> sortArrayByParity(std::vector<int>& nums) {
+    std::list<int> odd, even;
 
     for (const auto num : nums) {
       if (num % 2)

--- a/problems/0905/solution.cpp
+++ b/problems/0905/solution.cpp
@@ -13,7 +13,7 @@ class Solution {
         even.push_back(num);
     }
 
-    size_t i = 0;
+    std::size_t i = 0;
     for (const auto num : even) {
       nums[i++] = num;
     }

--- a/problems/0905/test.yaml
+++ b/problems/0905/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: sortArrayByParity
-    includes: [list, vector]
 
 test_cases:
   example_1:

--- a/problems/1048/solution.cpp
+++ b/problems/1048/solution.cpp
@@ -1,10 +1,14 @@
+#include <string>
+#include <unordered_map>
+#include <vector>
+
 class Solution {
  private:
-  unordered_map<int, vector<string>> m;
-  unordered_map<string, int> findMaxCache;
+  std::unordered_map<int, std::vector<std::string>> m;
+  std::unordered_map<std::string, int> findMaxCache;
 
  public:
-  int longestStrChain(vector<string>& words) {
+  int longestStrChain(std::vector<std::string>& words) {
     for (const auto& word : words) {
       m[word.size()].push_back(word);
     }

--- a/problems/1048/test.yaml
+++ b/problems/1048/test.yaml
@@ -8,10 +8,6 @@ types:
 solutions:
   cpp:
     function: longestStrChain
-    includes:
-      - string
-      - unordered_map
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1081/solution.cpp
+++ b/problems/1081/solution.cpp
@@ -6,7 +6,7 @@
 class Solution {
  public:
   std::string smallestSubsequence(std::string s) {
-    std::unordered_map<char, size_t> counts;
+    std::unordered_map<char, std::size_t> counts;
     for (const auto c : s) {
       ++counts[c];
     }

--- a/problems/1081/solution.cpp
+++ b/problems/1081/solution.cpp
@@ -1,13 +1,18 @@
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+
 class Solution {
  public:
-  string smallestSubsequence(string s) {
-    unordered_map<char, size_t> counts;
+  std::string smallestSubsequence(std::string s) {
+    std::unordered_map<char, size_t> counts;
     for (const auto c : s) {
       ++counts[c];
     }
 
-    unordered_set<char> existed;
-    stack<char> orders;
+    std::unordered_set<char> existed;
+    std::stack<char> orders;
 
     for (const auto c : s) {
       --counts[c];
@@ -22,7 +27,7 @@ class Solution {
       existed.insert(c);
     }
 
-    string res;
+    std::string res;
     while (!orders.empty()) {
       res = orders.top() + res;
       orders.pop();

--- a/problems/1081/test.yaml
+++ b/problems/1081/test.yaml
@@ -8,11 +8,6 @@ types:
 solutions:
   cpp:
     function: smallestSubsequence
-    includes:
-      - stack
-      - string
-      - unordered_map
-      - unordered_set
 
 test_cases:
   example_1:

--- a/problems/1232/solution.cpp
+++ b/problems/1232/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  bool checkStraightLine(vector<vector<int>>& coordinates) {
+  bool checkStraightLine(std::vector<std::vector<int>>& coordinates) {
     const auto x0 = coordinates[0][0];
     const auto y0 = coordinates[0][1];
     const auto w = coordinates[1][0] - x0;

--- a/problems/1232/solution.cpp
+++ b/problems/1232/solution.cpp
@@ -16,7 +16,7 @@ class Solution {
     }
 
     const auto n = coordinates.size();
-    for (size_t i = 2; i < n; ++i) {
+    for (std::size_t i = 2; i < n; ++i) {
       const auto x = coordinates[i][0] - x0;
       if (coordinates[i][1] - y0 != (x * h) / w) return false;
     }

--- a/problems/1232/test.yaml
+++ b/problems/1232/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: checkStraightLine
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/1269/solution.cpp
+++ b/problems/1269/solution.cpp
@@ -1,11 +1,15 @@
+#include <algorithm>
+#include <functional>
+#include <vector>
+
 const int mod = 1'000'000'007;
 
 class Solution {
  public:
   int numWays(int steps, int arrLen) {
-    auto cache = vector(steps + 1, vector(min(arrLen, steps) + 1, -1));
+    auto cache = std::vector(steps + 1, std::vector(std::min(arrLen, steps) + 1, -1));
 
-    const function<int(int, int)> fn = [&](int step, int index) {
+    const std::function<int(int, int)> fn = [&](int step, int index) {
       if (step == 0) return index == 0 ? 1 : 0;
       if (step < 0 || index < 0 || index >= arrLen) return 0;
       if (cache[step][index] < 0) {

--- a/problems/1269/test.yaml
+++ b/problems/1269/test.yaml
@@ -9,10 +9,6 @@ types:
 solutions:
   cpp:
     function: numWays
-    includes:
-      - algorithm
-      - functional
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1337/solution.cpp
+++ b/problems/1337/solution.cpp
@@ -1,7 +1,11 @@
+#include <map>
+#include <set>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> kWeakestRows(vector<vector<int>>& mat, int k) {
-    map<int, set<int, less<int>>, less<int>> m;
+  std::vector<int> kWeakestRows(std::vector<std::vector<int>>& mat, int k) {
+    std::map<int, std::set<int, std::less<int>>, std::less<int>> m;
 
     const int n = mat.size();
     for (int i = 0; i < n; ++i) {
@@ -14,7 +18,7 @@ class Solution {
     }
 
     int j = 0;
-    vector<int> res(k);
+    std::vector<int> res(k);
     for (const auto& [total, s] : m) {
       for (const auto i : s) {
         res[j] = i;

--- a/problems/1337/test.yaml
+++ b/problems/1337/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: kWeakestRows
-    includes: [map, set, vector]
 
 test_cases:
   example_1:

--- a/problems/1356/solution.cpp
+++ b/problems/1356/solution.cpp
@@ -1,7 +1,10 @@
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> sortByBits(vector<int>& arr) {
-    sort(arr.begin(), arr.end(), [](int a, int b) {
+  std::vector<int> sortByBits(std::vector<int>& arr) {
+    std::sort(arr.begin(), arr.end(), [](int a, int b) {
       int ai = __builtin_popcount(a);
       int bi = __builtin_popcount(b);
       return ai == bi ? a < b : ai < bi;

--- a/problems/1356/test.yaml
+++ b/problems/1356/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: sortByBits
-    includes: [algorithm, vector]
 
 test_cases:
   example_1:

--- a/problems/1361/solution.cpp
+++ b/problems/1361/solution.cpp
@@ -1,7 +1,11 @@
+#include <algorithm>
+#include <functional>
+#include <vector>
+
 class Solution {
  public:
-  bool validateBinaryTreeNodes(int n, vector<int>& leftChild, vector<int>& rightChild) {
-    vector<bool> exists(n, false);
+  bool validateBinaryTreeNodes(int n, std::vector<int>& leftChild, std::vector<int>& rightChild) {
+    std::vector<bool> exists(n, false);
     int count = 0;
 
     leftChild.insert(leftChild.end(), rightChild.begin(), rightChild.end());
@@ -15,13 +19,13 @@ class Solution {
     if (count != n - 1) return false;
 
     count = 0;
-    const function<void(int)> sweep = [&](int root) {
+    const std::function<void(int)> sweep = [&](int root) {
       ++count;
       if (leftChild[root] >= 0) sweep(leftChild[root]);
       if (rightChild[root] >= 0) sweep(rightChild[root]);
     };
 
-    const int root = distance(exists.begin(), find(exists.begin(), exists.end(), false));
+    const int root = std::distance(exists.begin(), find(exists.begin(), exists.end(), false));
     sweep(root);
 
     return count == n;

--- a/problems/1361/test.yaml
+++ b/problems/1361/test.yaml
@@ -11,10 +11,6 @@ solutions:
   c:
   cpp:
     function: validateBinaryTreeNodes
-    includes:
-      - algorithm
-      - functional
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1424/solution.cpp
+++ b/problems/1424/solution.cpp
@@ -9,15 +9,15 @@ class Solution {
  public:
   std::vector<int> findDiagonalOrder(std::vector<std::vector<int>>& nums) {
     // Calculate the maximum diagonal count.
-    size_t diagonalCount = 0;
-    for (size_t y = 0; y < nums.size(); ++y) {
+    std::size_t diagonalCount = 0;
+    for (std::size_t y = 0; y < nums.size(); ++y) {
       diagonalCount = std::max(diagonalCount, y + nums[y].size());
     }
 
     // Push each number into its diagonal.
     std::vector<std::list<int>> diagonals(diagonalCount);
-    for (size_t y = 0; y < nums.size(); ++y) {
-      for (size_t x = 0; x < nums[y].size(); ++x) {
+    for (std::size_t y = 0; y < nums.size(); ++y) {
+      for (std::size_t x = 0; x < nums[y].size(); ++x) {
         diagonals[y + x].push_front(nums[y][x]);
       }
     }

--- a/problems/1425/solution.cpp
+++ b/problems/1425/solution.cpp
@@ -1,7 +1,10 @@
+#include <deque>
+#include <vector>
+
 class Solution {
  public:
-  int constrainedSubsetSum(vector<int>& nums, int k) {
-    deque<int> dq;
+  int constrainedSubsetSum(std::vector<int>& nums, int k) {
+    std::deque<int> dq;
 
     const int n = nums.size();
     for (int i = 0; i < n; ++i) {

--- a/problems/1425/test.yaml
+++ b/problems/1425/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: constrainedSubsetSum
-    includes: [deque, vector]
 
 test_cases:
   example_1:

--- a/problems/1441/solution.cpp
+++ b/problems/1441/solution.cpp
@@ -1,7 +1,10 @@
+#include <string>
+#include <vector>
+
 class Solution {
  public:
-  vector<string> buildArray(vector<int>& target, int n) {
-    vector<string> cmds;
+  std::vector<std::string> buildArray(std::vector<int>& target, int n) {
+    std::vector<std::string> cmds;
 
     auto ti = target.begin();
     for (int i = 1; i <= n && ti != target.end(); ++i) {

--- a/problems/1441/test.yaml
+++ b/problems/1441/test.yaml
@@ -9,9 +9,6 @@ types:
 solutions:
   cpp:
     function: buildArray
-    includes:
-      - string
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1458/solution.cpp
+++ b/problems/1458/solution.cpp
@@ -19,9 +19,9 @@ class Solution {
       if (cache[i1][i2] > min_val) return cache[i1][i2];
 
       cache[i1][i2] = std::max({nums1[i1] * nums2[i2] + std::max(fn(i1 + 1, i2 + 1), 0),
-                           fn(i1 + 1, i2),
-                           fn(i1, i2 + 1),
-                           fn(i1 + 1, i2 + 1)});
+                                fn(i1 + 1, i2),
+                                fn(i1, i2 + 1),
+                                fn(i1 + 1, i2 + 1)});
 
       return cache[i1][i2];
     };

--- a/problems/1458/solution.cpp
+++ b/problems/1458/solution.cpp
@@ -1,19 +1,24 @@
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <vector>
+
 class Solution {
  public:
-  int maxDotProduct(vector<int>& nums1, vector<int>& nums2) {
-    static const int min_val = numeric_limits<int>::min();
+  int maxDotProduct(std::vector<int>& nums1, std::vector<int>& nums2) {
+    static const int min_val = std::numeric_limits<int>::min();
 
     const int n1 = nums1.size();
     const int n2 = nums2.size();
 
-    auto cache = vector(n1, vector(n2, min_val));
+    auto cache = std::vector(n1, std::vector(n2, min_val));
 
-    const function<int(int, int)> fn = [&](int i1, int i2) -> int {
+    const std::function<int(int, int)> fn = [&](int i1, int i2) -> int {
       if (i1 >= n1 || i2 >= n2) return min_val;
 
       if (cache[i1][i2] > min_val) return cache[i1][i2];
 
-      cache[i1][i2] = max({nums1[i1] * nums2[i2] + max(fn(i1 + 1, i2 + 1), 0),
+      cache[i1][i2] = std::max({nums1[i1] * nums2[i2] + std::max(fn(i1 + 1, i2 + 1), 0),
                            fn(i1 + 1, i2),
                            fn(i1, i2 + 1),
                            fn(i1 + 1, i2 + 1)});

--- a/problems/1458/test.yaml
+++ b/problems/1458/test.yaml
@@ -9,11 +9,6 @@ types:
 solutions:
   cpp:
     function: maxDotProduct
-    includes:
-      - algorithm
-      - functional
-      - limits
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1503/solution.cpp
+++ b/problems/1503/solution.cpp
@@ -2,13 +2,16 @@
 // Conceptually, we can ignore the collisions, and ant movement is as if they pass through each other.
 // Hence, the time required is the same as the position of the leftmost ant moving right or the rightmost ant moving left.
 
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  int getLastMoment(int n, vector<int>& left, vector<int>& right) {
-    if (left.empty()) return n - *min_element(right.begin(), right.end());
-    if (right.empty()) return *max_element(left.begin(), left.end());
-    return max(
-        n - *min_element(right.begin(), right.end()),
-        *max_element(left.begin(), left.end()));
+  int getLastMoment(int n, std::vector<int>& left, std::vector<int>& right) {
+    if (left.empty()) return n - *std::min_element(right.begin(), right.end());
+    if (right.empty()) return *std::max_element(left.begin(), left.end());
+    return std::max(
+        n - *std::min_element(right.begin(), right.end()),
+        *std::max_element(left.begin(), left.end()));
   }
 };

--- a/problems/1503/test.yaml
+++ b/problems/1503/test.yaml
@@ -11,9 +11,6 @@ solutions:
   c:
   cpp:
     function: getLastMoment
-    includes:
-      - algorithm
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1512/solution.cpp
+++ b/problems/1512/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int numIdenticalPairs(vector<int>& nums) {
+  int numIdenticalPairs(std::vector<int>& nums) {
     size_t count = 0;
     const size_t n = nums.size();
     for (size_t i = 0; i < n; ++i) {

--- a/problems/1512/solution.cpp
+++ b/problems/1512/solution.cpp
@@ -3,10 +3,10 @@
 class Solution {
  public:
   int numIdenticalPairs(std::vector<int>& nums) {
-    size_t count = 0;
-    const size_t n = nums.size();
-    for (size_t i = 0; i < n; ++i) {
-      for (size_t j = i + 1; j < n; ++j) {
+    std::size_t count = 0;
+    const std::size_t n = nums.size();
+    for (std::size_t i = 0; i < n; ++i) {
+      for (std::size_t j = i + 1; j < n; ++j) {
         if (nums[i] == nums[j]) ++count;
       }
     }

--- a/problems/1512/test.yaml
+++ b/problems/1512/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: numIdenticalPairs
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/1535/solution.cpp
+++ b/problems/1535/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int getWinner(vector<int>& arr, int k) {
+  int getWinner(std::vector<int>& arr, int k) {
     int win = 0;
     size_t ref = 0;
 

--- a/problems/1535/solution.cpp
+++ b/problems/1535/solution.cpp
@@ -4,9 +4,9 @@ class Solution {
  public:
   int getWinner(std::vector<int>& arr, int k) {
     int win = 0;
-    size_t ref = 0;
+    std::size_t ref = 0;
 
-    for (size_t i = 1; i < arr.size(); ++i) {
+    for (std::size_t i = 1; i < arr.size(); ++i) {
       if (win >= k) break;
       if (arr[i] > arr[ref]) {
         win = 1;

--- a/problems/1535/test.yaml
+++ b/problems/1535/test.yaml
@@ -10,7 +10,6 @@ solutions:
   c:
   cpp:
     function: getWinner
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/1561/solution.cpp
+++ b/problems/1561/solution.cpp
@@ -13,7 +13,7 @@ class Solution {
 
     // Iterate n / 3 times to get the second-highest pile in each iteration.
     int total = 0;
-    for (size_t i = 0; i < piles.size() / 3; ++i) {
+    for (std::size_t i = 0; i < piles.size() / 3; ++i) {
       total += piles[2 * i + 1];
     }
 

--- a/problems/1630/solution.cpp
+++ b/problems/1630/solution.cpp
@@ -12,7 +12,7 @@ class Solution {
     std::vector<bool> isArithmetics(n, true);
 
     // Iterating over the given subarrays.
-    for (size_t i = 0; i < n; ++i) {
+    for (std::size_t i = 0; i < n; ++i) {
       // Subarray with a size of 2 or less is always considered arithmetic.
       if (r[i] - l[i] <= 1) continue;
 
@@ -24,7 +24,7 @@ class Solution {
 
       // Check if the difference between each element is the same.
       const auto diff = subnums[1] - subnums[0];
-      for (size_t j = 2; j < subnums.size(); ++j) {
+      for (std::size_t j = 2; j < subnums.size(); ++j) {
         if (subnums[j] - subnums[j - 1] != diff) {
           isArithmetics[i] = false;
           break;

--- a/problems/1658/solution.cpp
+++ b/problems/1658/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int minOperations(vector<int>& nums, int x) {
+  int minOperations(std::vector<int>& nums, int x) {
     int res = -1;
     const int n = nums.size();
 
@@ -14,7 +16,7 @@ class Solution {
       if (xx <= 0) {
         if (xx == 0) {
           int new_res = ll + 1;
-          res = res > 0 ? min(res, new_res) : new_res;
+          res = res > 0 ? std::min(res, new_res) : new_res;
         }
         break;
       }
@@ -35,7 +37,7 @@ class Solution {
         xx -= nums[rr];
         if (xx == 0) {
           int new_res = ll + 1 + n - rr;
-          res = res > 0 ? min(res, new_res) : new_res;
+          res = res > 0 ? std::min(res, new_res) : new_res;
         }
         --rr;
       }

--- a/problems/1658/test.yaml
+++ b/problems/1658/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: minOperations
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/1685/solution.cpp
+++ b/problems/1685/solution.cpp
@@ -37,7 +37,7 @@ class Solution {
 
     // Iterate each element to update the output.
     int leftTotal = 0;
-    for (size_t i = 0; i < nums.size(); ++i) {
+    for (std::size_t i = 0; i < nums.size(); ++i) {
       // Shift value from the right total to the left total.
       leftTotal += nums[i];
       rightTotal -= nums[i];

--- a/problems/1727/c/interface.cpp
+++ b/problems/1727/c/interface.cpp
@@ -7,7 +7,7 @@ int largestSubmatrix(int** matrix, int matrixSize, int* matrixColSize);
 int solution_c(std::vector<std::vector<int>> matrix) {
   std::vector<int*> matrixData(matrix.size());
   std::vector<int> matrixColSize(matrix.size());
-  for (size_t i = 0; i < matrix.size(); ++i) {
+  for (std::size_t i = 0; i < matrix.size(); ++i) {
     matrixData[i] = matrix[i].data();
     matrixColSize[i] = matrix[i].size();
   }

--- a/problems/1727/solution.cpp
+++ b/problems/1727/solution.cpp
@@ -40,8 +40,8 @@ class Solution {
   int largestSubmatrix(std::vector<std::vector<int>>& matrix) {
     // Adjust each element of the matrix so it contains
     // 1 + the number of the above elements whose value is 1.
-    for (size_t y = 1; y < matrix.size(); ++y) {
-      for (size_t x = 0; x < matrix[y].size(); ++x) {
+    for (std::size_t y = 1; y < matrix.size(); ++y) {
+      for (std::size_t x = 0; x < matrix[y].size(); ++x) {
         if (matrix[y][x] == 0) continue;
         matrix[y][x] = matrix[y - 1][x] + 1;
       }
@@ -54,7 +54,7 @@ class Solution {
       sort(rows.begin(), rows.end(), std::greater<int>());
 
       // Find the largest area from values in the row.
-      for (size_t i = 0; i < rows.size(); ++i) {
+      for (std::size_t i = 0; i < rows.size(); ++i) {
         if (rows[i] == 0) break;
         maxArea = std::max<int>(maxArea, (i + 1) * rows[i]);
       }

--- a/problems/1743/solution.cpp
+++ b/problems/1743/solution.cpp
@@ -30,7 +30,7 @@ class Solution {
     // Repeatedly add adjacent values starting from the beginning value.
     int prev = begin->first;
     int current = begin->second.front();
-    for (size_t i = 1; i < res.size() - 1; ++i) {
+    for (std::size_t i = 1; i < res.size() - 1; ++i) {
       for (auto adjacent : adjacents[current]) {
         if (adjacent == prev) continue;
         res[i] = prev = current;

--- a/problems/1743/solution.cpp
+++ b/problems/1743/solution.cpp
@@ -3,23 +3,28 @@
 // - Find the beginning (or the end) of the array's value. This can be done by searching for a value in the hash map that has only one adjacent value.
 // - Recursively construct the array by putting adjacent values starting from the beginning value.
 
+#include <algorithm>
+#include <list>
+#include <unordered_map>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> restoreArray(vector<vector<int>>& adjacentPairs) {
+  std::vector<int> restoreArray(std::vector<std::vector<int>>& adjacentPairs) {
     // Convert to a hash map. Both values of the pair will be associated with different keys.
-    unordered_map<int, list<int>> adjacents;
+    std::unordered_map<int, std::list<int>> adjacents;
     for (const auto& pair : adjacentPairs) {
       adjacents[pair[0]].push_back(pair[1]);
       adjacents[pair[1]].push_back(pair[0]);
     }
 
     // Find the beginning (or the end) of the array's value.
-    const auto begin = find_if(adjacents.begin(), adjacents.end(), [](const auto& pair) {
+    const auto begin = std::find_if(adjacents.begin(), adjacents.end(), [](const auto& pair) {
       return pair.second.size() == 1;
     });
 
     // Construct the array starting with the beginning value.
-    vector<int> res(adjacentPairs.size() + 1);
+    std::vector<int> res(adjacentPairs.size() + 1);
     res[0] = begin->first;
 
     // Repeatedly add adjacent values starting from the beginning value.

--- a/problems/1743/test.yaml
+++ b/problems/1743/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: restoreArray
-    includes: [algorithm, list, unordered_map, vector]
 
 test_cases:
   example_1:

--- a/problems/1759/solution.cpp
+++ b/problems/1759/solution.cpp
@@ -1,5 +1,7 @@
 const long long mod = 1'000'000'007;
 
+#include <string>
+
 class Solution {
  public:
   // The count of homogeneous substrings is equal to the sum of the series of the maximum length of homogeneous substrings.
@@ -18,7 +20,7 @@ class Solution {
   //
   // Or, roughly speaking, it equals the sum of the series from 1 to 2 (from "aa") and the series from 1 to 3 (from "bbb").
   //
-  int countHomogenous(string s) {
+  int countHomogenous(std::string s) {
     long long total = 0;
 
     // Find the maximum length of each homogeneous substring and sum the series.

--- a/problems/1759/test.yaml
+++ b/problems/1759/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: countHomogenous
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/1793/solution.cpp
+++ b/problems/1793/solution.cpp
@@ -1,6 +1,8 @@
+#include <vector>
+
 class Solution {
  public:
-  int maximumScore(vector<int>& nums, int k) {
+  int maximumScore(std::vector<int>& nums, int k) {
     int left = k;
     int right = k;
 
@@ -11,13 +13,13 @@ class Solution {
     while (left > 0 || right < n - 1) {
       if (left == 0 || (right < n - 1 && nums[right + 1] > nums[left - 1])) {
         ++right;
-        minNum = min(minNum, nums[right]);
+        minNum = std::min(minNum, nums[right]);
       } else {
         --left;
-        minNum = min(minNum, nums[left]);
+        minNum = std::min(minNum, nums[left]);
       }
 
-      maxScore = max(maxScore, minNum * (right - left + 1));
+      maxScore = std::max(maxScore, minNum * (right - left + 1));
     }
 
     return maxScore;

--- a/problems/1793/test.yaml
+++ b/problems/1793/test.yaml
@@ -10,7 +10,6 @@ solutions:
   c:
   cpp:
     function: maximumScore
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/1838/solution.cpp
+++ b/problems/1838/solution.cpp
@@ -1,10 +1,13 @@
 // TLDR: I don't know how they derived this solution, I just found it in the editorial:
 // https://leetcode.com/problems/frequency-of-the-most-frequent-element/editorial/
 
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  int maxFrequency(vector<int>& nums, int k) {
-    sort(nums.begin(), nums.end());
+  int maxFrequency(std::vector<int>& nums, int k) {
+    std::sort(nums.begin(), nums.end());
 
     size_t left = 0;
     long curr = 0;

--- a/problems/1838/solution.cpp
+++ b/problems/1838/solution.cpp
@@ -9,9 +9,9 @@ class Solution {
   int maxFrequency(std::vector<int>& nums, int k) {
     std::sort(nums.begin(), nums.end());
 
-    size_t left = 0;
+    std::size_t left = 0;
     long curr = 0;
-    for (size_t right = 0; right < nums.size(); ++right) {
+    for (std::size_t right = 0; right < nums.size(); ++right) {
       curr += nums[right];
       if (long(right - left + 1) * nums[right] - curr > k) {
         curr -= nums[left];

--- a/problems/1838/test.yaml
+++ b/problems/1838/test.yaml
@@ -9,9 +9,6 @@ types:
 solutions:
   cpp:
     function: maxFrequency
-    includes:
-      - algorithm
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1846/solution.cpp
+++ b/problems/1846/solution.cpp
@@ -1,17 +1,20 @@
 // The solution can be done simply by sorting the array from lowest to highest
 // and then iterating through the array following the rules so that the difference between each element should be equal to or less than 1.
 
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  int maximumElementAfterDecrementingAndRearranging(vector<int>& arr) {
+  int maximumElementAfterDecrementingAndRearranging(std::vector<int>& arr) {
     // Sort the array from the lowest to the highest.
-    sort(arr.begin(), arr.end());
+    std::sort(arr.begin(), arr.end());
 
     // Iterating through the elements for calculating the highest possible value.
     // The highest value is at the end of the array, but each next element should be capped if the difference is more than 1.
     int res = 0;
     for (const auto num : arr) {
-      res = min(res + 1, num);
+      res = std::min(res + 1, num);
     }
 
     return res;

--- a/problems/1846/test.yaml
+++ b/problems/1846/test.yaml
@@ -9,9 +9,6 @@ solutions:
   c:
   cpp:
     function: maximumElementAfterDecrementingAndRearranging
-    includes:
-      - algorithm
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1877/solution.cpp
+++ b/problems/1877/solution.cpp
@@ -11,8 +11,8 @@ class Solution {
     std::sort(nums.begin(), nums.end());
 
     // Declare left and right pointers.
-    size_t left = 0;
-    size_t right = nums.size() - 1;
+    std::size_t left = 0;
+    std::size_t right = nums.size() - 1;
 
     // Iterate from left and right to get the maximum sum of each pair.
     int res = 0;

--- a/problems/1877/solution.cpp
+++ b/problems/1877/solution.cpp
@@ -1,11 +1,14 @@
 // The solution can be done simply by first sorting the array and then
 // iterating from left and right to get the minimized sum of pairs.
 
+#include <algorithm>
+#include <vector>
+
 class Solution {
  public:
-  int minPairSum(vector<int>& nums) {
+  int minPairSum(std::vector<int>& nums) {
     // Sort the given array.
-    sort(nums.begin(), nums.end());
+    std::sort(nums.begin(), nums.end());
 
     // Declare left and right pointers.
     size_t left = 0;
@@ -14,7 +17,7 @@ class Solution {
     // Iterate from left and right to get the maximum sum of each pair.
     int res = 0;
     while (left < right) {
-      res = max(res, nums[left] + nums[right]);
+      res = std::max(res, nums[left] + nums[right]);
       ++left;
       --right;
     }

--- a/problems/1877/test.yaml
+++ b/problems/1877/test.yaml
@@ -9,9 +9,6 @@ solutions:
   c:
   cpp:
     function: minPairSum
-    includes:
-      - algorithm
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1887/test.yaml
+++ b/problems/1887/test.yaml
@@ -9,8 +9,6 @@ solutions:
   c:
   cpp:
     function: reductionOperations
-    includes:
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1921/solution.cpp
+++ b/problems/1921/solution.cpp
@@ -1,14 +1,18 @@
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 class Solution {
  public:
-  int eliminateMaximum(vector<int>& dist, vector<int>& speed) {
+  int eliminateMaximum(std::vector<int>& dist, std::vector<int>& speed) {
     // Calculate the time required before enemies reach distance zero.
-    int n = min(dist.size(), speed.size());
+    int n = std::min(dist.size(), speed.size());
     for (int i = 0; i < n; ++i) {
       dist[i] = dist[i] / speed[i] + (dist[i] % speed[i] > 0 ? 1 : 0);
     }
 
     // Sort the time required from lowest to highest.
-    sort(dist.begin(), dist.end());
+    std::sort(dist.begin(), dist.end());
 
     // Time equals to kills. Iterate through the time required as long as the current time is not greater than the time required.
     int kills = 0;

--- a/problems/1921/test.yaml
+++ b/problems/1921/test.yaml
@@ -10,10 +10,6 @@ solutions:
   c:
   cpp:
     function: eliminateMaximum
-    includes:
-      - algorithm
-      - limits
-      - vector
 
 test_cases:
   example_1:

--- a/problems/1930/solution.cpp
+++ b/problems/1930/solution.cpp
@@ -10,8 +10,8 @@ class Solution {
  public:
   int countPalindromicSubsequence(std::string s) {
     // Find the left and right pointers of each character.
-    std::unordered_map<char, std::pair<size_t, size_t>> charsPos;
-    for (size_t i = 0; i < s.size(); ++i) {
+    std::unordered_map<char, std::pair<std::size_t, std::size_t>> charsPos;
+    for (std::size_t i = 0; i < s.size(); ++i) {
       const auto it = charsPos.find(s[i]);
       if (it == charsPos.end())
         charsPos[s[i]] = {i, i};

--- a/problems/1930/solution.cpp
+++ b/problems/1930/solution.cpp
@@ -1,11 +1,16 @@
 // The problem can be solved by finding the left and right pointers of each character
 // and then counting the unique characters between those pointers.
 
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
 class Solution {
  public:
-  int countPalindromicSubsequence(string s) {
+  int countPalindromicSubsequence(std::string s) {
     // Find the left and right pointers of each character.
-    unordered_map<char, pair<size_t, size_t>> charsPos;
+    std::unordered_map<char, std::pair<size_t, size_t>> charsPos;
     for (size_t i = 0; i < s.size(); ++i) {
       const auto it = charsPos.find(s[i]);
       if (it == charsPos.end())
@@ -17,7 +22,7 @@ class Solution {
     // Count the number of unique characters between each pair of pointers.
     int count = 0;
     for (const auto& [c, pos] : charsPos) {
-      unordered_set<char> chars;
+      std::unordered_set<char> chars;
       for (auto i = pos.first + 1; i < pos.second; ++i) {
         chars.insert(s[i]);
       }

--- a/problems/1930/test.yaml
+++ b/problems/1930/test.yaml
@@ -9,11 +9,6 @@ solutions:
   c:
   cpp:
     function: countPalindromicSubsequence
-    includes:
-      - string
-      - unordered_map
-      - unordered_set
-      - utility
 
 test_cases:
   example_1:

--- a/problems/1980/solution.cpp
+++ b/problems/1980/solution.cpp
@@ -4,14 +4,18 @@
 // - For each binary number, compare it with the iterator.
 // - If it is equal, increment the iterator; otherwise, return the iterator.
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 class Solution {
  public:
-  string findDifferentBinaryString(vector<string>& nums) {
+  std::string findDifferentBinaryString(std::vector<std::string>& nums) {
     // Sort the binary numbers.
-    sort(nums.begin(), nums.end());
+    std::sort(nums.begin(), nums.end());
 
     // Declare a binary number 0 as an iterator.
-    string res(nums.size(), '0');
+    std::string res(nums.size(), '0');
 
     // For each binary number, compare it with the iterator.
     for (const auto& num : nums) {

--- a/problems/1980/test.yaml
+++ b/problems/1980/test.yaml
@@ -8,10 +8,6 @@ types:
 solutions:
   cpp:
     function: findDifferentBinaryString
-    includes:
-      - algorithm
-      - string
-      - vector
 
 test_cases:
   example_1:

--- a/problems/2009/solution.cpp
+++ b/problems/2009/solution.cpp
@@ -1,18 +1,22 @@
+#include <algorithm>
+#include <limits>
+#include <vector>
+
 class Solution {
  public:
-  int minOperations(vector<int>& nums) {
+  int minOperations(std::vector<int>& nums) {
     const int n = nums.size();
-    sort(nums.begin(), nums.end());
+    std::sort(nums.begin(), nums.end());
 
-    const auto unique_nums = vector(nums.begin(), unique(nums.begin(), nums.end()));
+    const auto unique_nums = std::vector(nums.begin(), std::unique(nums.begin(), nums.end()));
     const int unique_n = unique_nums.size();
 
-    int res = numeric_limits<int>::max();
+    int res = std::numeric_limits<int>::max();
     for (int a = 0; a < unique_n; ++a) {
       const int b_val = unique_nums[a] + n - 1;
-      const auto it = upper_bound(unique_nums.begin(), unique_nums.end(), b_val);
-      const int b = distance(unique_nums.begin(), it);
-      res = min(res, n - (b - a));
+      const auto it = std::upper_bound(unique_nums.begin(), unique_nums.end(), b_val);
+      const int b = std::distance(unique_nums.begin(), it);
+      res = std::min(res, n - (b - a));
     }
 
     return res;

--- a/problems/2009/test.yaml
+++ b/problems/2009/test.yaml
@@ -8,10 +8,6 @@ types:
 solutions:
   cpp:
     function: minOperations
-    includes:
-      - algorithm
-      - limits
-      - vector
 
 test_cases:
   example_1:

--- a/problems/2038/solution.cpp
+++ b/problems/2038/solution.cpp
@@ -1,6 +1,8 @@
+#include <string>
+
 class Solution {
  public:
-  bool winnerOfGame(string colors) {
+  bool winnerOfGame(std::string colors) {
     size_t a = 0;
     size_t b = 0;
 

--- a/problems/2038/solution.cpp
+++ b/problems/2038/solution.cpp
@@ -3,12 +3,12 @@
 class Solution {
  public:
   bool winnerOfGame(std::string colors) {
-    size_t a = 0;
-    size_t b = 0;
+    std::size_t a = 0;
+    std::size_t b = 0;
 
-    size_t start = 0;
-    const size_t n = colors.size();
-    for (size_t i = 1; i < n; ++i) {
+    std::size_t start = 0;
+    const std::size_t n = colors.size();
+    for (std::size_t i = 1; i < n; ++i) {
       if (colors[i] != colors[start]) {
         if (i - start > 2) {
           if (colors[start] == 'A') {

--- a/problems/2038/test.yaml
+++ b/problems/2038/test.yaml
@@ -9,7 +9,6 @@ solutions:
   c:
   cpp:
     function: winnerOfGame
-    includes: [string]
 
 test_cases:
   example_1:

--- a/problems/2050/solution.cpp
+++ b/problems/2050/solution.cpp
@@ -1,10 +1,16 @@
+#include <algorithm>
+#include <list>
+#include <memory>
+#include <optional>
+#include <vector>
+
 class Course {
  public:
   int time;
-  list<shared_ptr<Course>> dependencies;
+  std::list<std::shared_ptr<Course>> dependencies;
 
  private:
-  mutable optional<int> totalTimeCache;
+  mutable std::optional<int> totalTimeCache;
 
  public:
   Course(int time);
@@ -19,7 +25,7 @@ int Course::totalTime() const {
     // Recursively collect the maximum time from all dependencies.
     int maxTime = 0;
     for (const auto& dependency : dependencies) {
-      maxTime = max(maxTime, dependency->totalTime());
+      maxTime = std::max(maxTime, dependency->totalTime());
     }
     totalTimeCache = maxTime + time;
   }
@@ -29,11 +35,11 @@ int Course::totalTime() const {
 
 class Solution {
  public:
-  int minimumTime(int n, vector<vector<int>>& relations, vector<int>& time) {
+  int minimumTime(int n, std::vector<std::vector<int>>& relations, std::vector<int>& time) {
     // Initialize list of courses that contains time.
-    vector<shared_ptr<Course>> courses(n);
+    std::vector<std::shared_ptr<Course>> courses(n);
     for (int i = 0; i < n; ++i) {
-      courses[i] = make_shared<Course>(time[i]);
+      courses[i] = std::make_shared<Course>(time[i]);
     }
 
     // Initialize dependencies of each course.
@@ -44,7 +50,7 @@ class Solution {
     // Find the maximum time of each course.
     int maxTime = 0;
     for (const auto& course : courses) {
-      maxTime = max(maxTime, course->totalTime());
+      maxTime = std::max(maxTime, course->totalTime());
     }
 
     return maxTime;

--- a/problems/2050/test.yaml
+++ b/problems/2050/test.yaml
@@ -10,12 +10,6 @@ types:
 solutions:
   cpp:
     function: minimumTime
-    includes:
-      - algorithm
-      - list
-      - memory
-      - optional
-      - vector
 
 test_cases:
   example_1:

--- a/problems/2251/solution.cpp
+++ b/problems/2251/solution.cpp
@@ -1,7 +1,11 @@
+#include <algorithm>
+#include <map>
+#include <vector>
+
 class Solution {
  public:
-  vector<int> fullBloomFlowers(vector<vector<int>>& flowers, vector<int>& people) {
-    map<int, int, less<int>> positions;
+  std::vector<int> fullBloomFlowers(std::vector<std::vector<int>>& flowers, std::vector<int>& people) {
+    std::map<int, int, std::less<int>> positions;
     for (auto person : people) {
       positions[person] = 0;
     }
@@ -9,7 +13,7 @@ class Solution {
     sort(flowers.begin(), flowers.end(), [](const auto& a, const auto& b) { return a[0] < b[0]; });
     auto flower = flowers.begin();
 
-    vector<int> ends;
+    std::vector<int> ends;
     for (auto& position : positions) {
       ends.erase(
           remove_if(ends.begin(), ends.end(), [=](auto end) { return end < position.first; }), ends.end());

--- a/problems/2251/test.yaml
+++ b/problems/2251/test.yaml
@@ -9,7 +9,6 @@ types:
 solutions:
   cpp:
     function: fullBloomFlowers
-    includes: [algorithm, map, vector]
 
 test_cases:
   example_1:

--- a/problems/2391/c/interface.cpp
+++ b/problems/2391/c/interface.cpp
@@ -7,7 +7,7 @@ int garbageCollection(char** garbage, int garbageSize, int* travel, int travelSi
 
 int solution_c(std::vector<std::string> garbage, std::vector<int> travel) {
   std::vector<char*> garbagePtr(garbage.size());
-  for (size_t i = 0; i < garbage.size(); ++i) {
+  for (std::size_t i = 0; i < garbage.size(); ++i) {
     garbagePtr[i] = garbage[i].data();
   }
 

--- a/problems/2391/solution.cpp
+++ b/problems/2391/solution.cpp
@@ -15,10 +15,10 @@ class Solution {
     int travelTime[3] = {0};
 
     // Iterating over the garbage in every house.
-    for (size_t i = 0; i < garbage.size(); ++i) {
+    for (std::size_t i = 0; i < garbage.size(); ++i) {
       // Remember the travel time, don't add it to the total time yet.
       if (i > 0) {
-        for (size_t j = 0; j < 3; ++j) {
+        for (std::size_t j = 0; j < 3; ++j) {
           travelTime[j] += travel[i - 1];
         }
       }
@@ -36,7 +36,7 @@ class Solution {
       }
 
       // Add garbage count and travel time if there's some garbage in the house.
-      for (size_t j = 0; j < 3; ++j) {
+      for (std::size_t j = 0; j < 3; ++j) {
         if (time[j] > 0) {
           totalTime[j] += travelTime[j] + time[j];
           travelTime[j] = 0;

--- a/problems/2433/solution.cpp
+++ b/problems/2433/solution.cpp
@@ -4,7 +4,7 @@ class Solution {
  public:
   std::vector<int> findArray(std::vector<int>& pref) {
     std::vector<int> res = pref;
-    for (size_t i = 1; i < res.size(); ++i) {
+    for (std::size_t i = 1; i < res.size(); ++i) {
       res[i] = pref[i - 1] ^ pref[i];
     }
     return res;

--- a/problems/2433/solution.cpp
+++ b/problems/2433/solution.cpp
@@ -1,7 +1,9 @@
+#include <vector>
+
 class Solution {
  public:
-  vector<int> findArray(vector<int>& pref) {
-    vector<int> res = pref;
+  std::vector<int> findArray(std::vector<int>& pref) {
+    std::vector<int> res = pref;
     for (size_t i = 1; i < res.size(); ++i) {
       res[i] = pref[i - 1] ^ pref[i];
     }

--- a/problems/2433/test.yaml
+++ b/problems/2433/test.yaml
@@ -8,7 +8,6 @@ types:
 solutions:
   cpp:
     function: findArray
-    includes: [vector]
 
 test_cases:
   example_1:

--- a/problems/2742/solution.cpp
+++ b/problems/2742/solution.cpp
@@ -1,14 +1,18 @@
+#include <algorithm>
+#include <functional>
+#include <vector>
+
 class Solution {
  public:
-  int paintWalls(vector<int>& cost, vector<int>& time) {
-    const int n = min(cost.size(), time.size());
+  int paintWalls(std::vector<int>& cost, std::vector<int>& time) {
+    const int n = std::min(cost.size(), time.size());
 
-    auto cache = vector(n + 1, vector(n + 1, -1));
-    const function<int(int, int)> fn = [&](int i, int left) -> int {
+    auto cache = std::vector(n + 1, std::vector(n + 1, -1));
+    const std::function<int(int, int)> fn = [&](int i, int left) -> int {
       if (left <= 0) return 0;
       if (i >= n) return 1'000'000'000;
       if (cache[i][left] >= 0) return cache[i][left];
-      return cache[i][left] = min(
+      return cache[i][left] = std::min(
                  cost[i] + fn(i + 1, left - time[i] - 1),
                  fn(i + 1, left));
     };

--- a/problems/2742/test.yaml
+++ b/problems/2742/test.yaml
@@ -9,10 +9,6 @@ types:
 solutions:
   cpp:
     function: paintWalls
-    includes:
-      - algorithm
-      - functional
-      - vector
 
 test_cases:
   example_1:

--- a/problems/2785/solution.cpp
+++ b/problems/2785/solution.cpp
@@ -1,10 +1,13 @@
 // The solution can be done by counting the number of vowel occurrences and then replacing each vowel using that count as references.
 
+#include <map>
+#include <string>
+
 class Solution {
  public:
-  string sortVowels(string s) {
+  std::string sortVowels(std::string s) {
     // Initializes a map for storing the count of vowels.
-    map<char, int> vowelsCount{
+    std::map<char, int> vowelsCount{
         {'A', 0}, {'E', 0}, {'I', 0}, {'O', 0}, {'U', 0}, {'a', 0}, {'e', 0}, {'i', 0}, {'o', 0}, {'u', 0}};
 
     // Count vowels in a string and store it in the map.

--- a/problems/2785/test.yaml
+++ b/problems/2785/test.yaml
@@ -9,9 +9,6 @@ solutions:
   c:
   cpp:
     function: sortVowels
-    includes:
-      - map
-      - string
 
 test_cases:
   example_1:

--- a/problems/2849/solution.cpp
+++ b/problems/2849/solution.cpp
@@ -1,3 +1,6 @@
+#include <algorithm>
+#include <cmath>
+
 class Solution {
  public:
   bool isReachableAtTime(int sx, int sy, int fx, int fy, int t) {
@@ -5,6 +8,6 @@ class Solution {
     if (sx == fx && sy == fy && t == 1) return false;
 
     // Time to reach is equal to the largest distance between x and y axes.
-    return max(abs(fx - sx), abs(fy - sy)) <= t;
+    return std::max(std::abs(fx - sx), std::abs(fy - sy)) <= t;
   }
 };

--- a/problems/2849/test.yaml
+++ b/problems/2849/test.yaml
@@ -13,7 +13,6 @@ solutions:
   c:
   cpp:
     function: isReachableAtTime
-    includes: [algorithm, cmath]
 
 test_cases:
   example_1:


### PR DESCRIPTION
This pull request removes support to set include headers from test config file in favor of setting it directly on the source files. This changes also discourage the usage of `using namespace std`, so we'll see a lot of thing prefixed with `std::` in this change. It closes #242.