### PR TITLE
Bump CheckWarning.cmake to Version 2.0.1

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -17,7 +17,7 @@ CPMDeclarePackage(Catch2
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 1.1.0
+  VERSION 2.0.1
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request simply bumps CheckWarning.cmake to version 2.0.1. 