### PR TITLE
Set C++ Standard Globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,9 @@ project(leetspace)
 
 include(cmake/CPM.cmake)
 
+cpmgetpackage(CheckWarning.cmake)
+add_check_warning()
+
 cpmgetpackage(Format.cmake)
 
 enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.19)
 
 project(leetspace)
 
+set(CMAKE_CXX_STANDARD 20)
+
 include(cmake/CPM.cmake)
 
 cpmgetpackage(CheckWarning.cmake)

--- a/problems/2353/CMakeLists.txt
+++ b/problems/2353/CMakeLists.txt
@@ -2,6 +2,5 @@ get_dir_name(id)
 
 add_executable(test-${id} test.cpp)
 target_link_libraries(test-${id} PRIVATE Catch2::Catch2WithMain)
-target_set_cpp_standard(test-${id})
 
 catch_discover_tests(test-${id})

--- a/problems/2642/CMakeLists.txt
+++ b/problems/2642/CMakeLists.txt
@@ -2,6 +2,5 @@ get_dir_name(id)
 
 add_executable(test-${id} test.cpp)
 target_link_libraries(test-${id} PRIVATE Catch2::Catch2WithMain)
-target_set_cpp_standard(test-${id})
 
 catch_discover_tests(test-${id})

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -4,9 +4,6 @@ endmacro()
 
 function(target_set_cpp_standard target)
   set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
-
-  cpmgetpackage(CheckWarning.cmake)
-  target_check_warning(${target})
 endfunction()
 
 macro(add_c_solution target)

--- a/problems/CMakeLists.txt
+++ b/problems/CMakeLists.txt
@@ -2,16 +2,11 @@ macro(get_dir_name var)
   get_filename_component(${var} ${CMAKE_CURRENT_SOURCE_DIR} NAME)
 endmacro()
 
-function(target_set_cpp_standard target)
-  set_property(TARGET ${target} PROPERTY CXX_STANDARD 20)
-endfunction()
-
 macro(add_c_solution target)
   get_dir_name(id)
   set(${target} c-solution-${id})
 
   add_library(c-solution-${id} ${ARGN})
-  target_set_cpp_standard(c-solution-${id})
 endmacro()
 
 function(add_problem_test TARGET CONFIG)
@@ -21,7 +16,6 @@ function(add_problem_test TARGET CONFIG)
   # Add a test target that includes the generated C++ source file.
   add_executable(${TARGET} ${CMAKE_CURRENT_BINARY_DIR}/src/test.cpp ${CMAKE_CURRENT_BINARY_DIR}/src/solution_cpp.cpp)
   target_link_libraries(${TARGET} PRIVATE Catch2::Catch2WithMain)
-  target_set_cpp_standard(${TARGET})
 
   catch_discover_tests(${TARGET})
 endfunction()


### PR DESCRIPTION
This pull request resolves #319 by introducing the following changes:
- Sets `CMAKE_CXX_STANDARD` variable instead of using `set_property(TARGET)` on each target.
- Uses `add_check_warning` function instead of using `target_check_warning` on each target.