### PR TITLE
Solve Problem 2870. Minimum Number of Operations to Make Array Empty With Sorting

### DIFF
--- a/problems/2870/solution.cpp
+++ b/problems/2870/solution.cpp
@@ -1,21 +1,31 @@
-#include <unordered_map>
+#include <algorithm>
 #include <vector>
 
 class Solution {
  public:
   int minOperations(std::vector<int>& nums) {
-    std::unordered_map<int, int> counts;
-
-    for (const auto num : nums) {
-      ++counts[num];
-    }
+    sort(nums.begin(), nums.end());
 
     int operations = 0;
-    for (const auto [num, count] : counts) {
+    int num = nums[0];
+    int count = 1;
+    for (std::size_t i = 1; i < nums.size(); ++i) {
+      if (nums[i] == num) {
+        ++count;
+        continue;
+      }
+
       if (count < 2) return -1;
       operations += count / 3;
       if (count % 3 > 0) ++operations;
+
+      num = nums[i];
+      count = 1;
     }
+
+    if (count < 2) return -1;
+    operations += count / 3;
+    if (count % 3 > 0) ++operations;
 
     return operations;
   }


### PR DESCRIPTION
This pull request updates the solution for problem [2870. Minimum Number of Operations to Make Array Empty](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-empty/) by using sorting instead of hash map.