### PR TITLE
Bump Catch2 to Version 3.5.3

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -10,7 +10,7 @@ CPMDeclarePackage(Format.cmake
 )
 # Catch2
 CPMDeclarePackage(Catch2
-  VERSION 3.5.2
+  VERSION 3.5.3
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request simply bumps the Catch2 to version [3.5.3](https://github.com/catchorg/Catch2/releases/tag/v3.5.3).