### PR TITLE
Remove Clang Format Disable Comment

### DIFF
--- a/problems/2391/c/solution.c
+++ b/problems/2391/c/solution.c
@@ -1,9 +1,11 @@
 // The solution can simply be done by iterating over the garbage to sum the required times.
 // To calculate the travel time, one should only add it to the total time if there's some garbage in a house.
 
-// clang-format off
-enum GarbageType { Metal = 0, Paper, Glass };
-// clang-format on
+enum GarbageType {
+  Metal = 0,
+  Paper,
+  Glass
+};
 
 int garbageCollection(char** garbage, int garbageSize, int* travel, int travelSize) {
   (void)travelSize;
@@ -25,11 +27,15 @@ int garbageCollection(char** garbage, int garbageSize, int* travel, int travelSi
     char* ci = garbage[i];
     while (*ci != 0) {
       switch (*ci) {
-        // clang-format off
-        case 'M': ++time[Metal]; break;
-        case 'P': ++time[Paper]; break;
-        case 'G': ++time[Glass]; break;
-          // clang-format on
+        case 'M':
+          ++time[Metal];
+          break;
+        case 'P':
+          ++time[Paper];
+          break;
+        case 'G':
+          ++time[Glass];
+          break;
       }
       ++ci;
     }

--- a/problems/2391/solution.cpp
+++ b/problems/2391/solution.cpp
@@ -4,9 +4,11 @@
 #include <string>
 #include <vector>
 
-// clang-format off
-enum GarbageType { Metal = 0, Paper, Glass };
-// clang-format on
+enum GarbageType {
+  Metal = 0,
+  Paper,
+  Glass
+};
 
 class Solution {
  public:
@@ -27,11 +29,15 @@ class Solution {
       int time[3] = {0};
       for (const auto c : garbage[i]) {
         switch (c) {
-          // clang-format off
-          case 'M': ++time[Metal]; break;
-          case 'P': ++time[Paper]; break;
-          case 'G': ++time[Glass]; break;
-            // clang-format on
+          case 'M':
+            ++time[Metal];
+            break;
+          case 'P':
+            ++time[Paper];
+            break;
+          case 'G':
+            ++time[Glass];
+            break;
         }
       }
 

--- a/problems/2785/c/solution.c
+++ b/problems/2785/c/solution.c
@@ -1,9 +1,18 @@
 // The solution can be done by counting the number of vowel occurrences and then replacing each vowel using that count as references.
 
 // This enum helps store the count of vowels in an array.
-// clang-format off
-enum { A = 0, E, I, O, U, a, e, i, o, u };
-// clang-format on
+enum {
+  A = 0,
+  E,
+  I,
+  O,
+  U,
+  a,
+  e,
+  i,
+  o,
+  u
+};
 
 char* sortVowels(char* s) {
   int vowelsCount[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
@@ -13,18 +22,36 @@ char* sortVowels(char* s) {
   while (*c != 0) {
     // Switch case is used for faster lookup.
     switch (*c) {
-      // clang-format off
-      case 'A': ++vowelsCount[A]; break;
-      case 'E': ++vowelsCount[E]; break;
-      case 'I': ++vowelsCount[I]; break;
-      case 'O': ++vowelsCount[O]; break;
-      case 'U': ++vowelsCount[U]; break;
-      case 'a': ++vowelsCount[a]; break;
-      case 'e': ++vowelsCount[e]; break;
-      case 'i': ++vowelsCount[i]; break;
-      case 'o': ++vowelsCount[o]; break;
-      case 'u': ++vowelsCount[u]; break;
-        // clang-format on
+      case 'A':
+        ++vowelsCount[A];
+        break;
+      case 'E':
+        ++vowelsCount[E];
+        break;
+      case 'I':
+        ++vowelsCount[I];
+        break;
+      case 'O':
+        ++vowelsCount[O];
+        break;
+      case 'U':
+        ++vowelsCount[U];
+        break;
+      case 'a':
+        ++vowelsCount[a];
+        break;
+      case 'e':
+        ++vowelsCount[e];
+        break;
+      case 'i':
+        ++vowelsCount[i];
+        break;
+      case 'o':
+        ++vowelsCount[o];
+        break;
+      case 'u':
+        ++vowelsCount[u];
+        break;
     }
     ++c;
   }
@@ -35,7 +62,6 @@ char* sortVowels(char* s) {
   while (*c != 0) {
     // Switch case is used for faster lookup.
     switch (*c) {
-      // clang-format off
       case 'A':
       case 'E':
       case 'I':
@@ -48,20 +74,39 @@ char* sortVowels(char* s) {
       case 'u':
         while (vowelsCount[vowel] <= 0) ++vowel;
         switch (vowel) {
-          case A: *c = 'A'; break;
-          case E: *c = 'E'; break;
-          case I: *c = 'I'; break;
-          case O: *c = 'O'; break;
-          case U: *c = 'U'; break;
-          case a: *c = 'a'; break;
-          case e: *c = 'e'; break;
-          case i: *c = 'i'; break;
-          case o: *c = 'o'; break;
-          case u: *c = 'u'; break;
+          case A:
+            *c = 'A';
+            break;
+          case E:
+            *c = 'E';
+            break;
+          case I:
+            *c = 'I';
+            break;
+          case O:
+            *c = 'O';
+            break;
+          case U:
+            *c = 'U';
+            break;
+          case a:
+            *c = 'a';
+            break;
+          case e:
+            *c = 'e';
+            break;
+          case i:
+            *c = 'i';
+            break;
+          case o:
+            *c = 'o';
+            break;
+          case u:
+            *c = 'u';
+            break;
         }
         --vowelsCount[vowel];
         break;
-        // clang-format on
     }
     ++c;
   }


### PR DESCRIPTION
This pull request resolves #688 by removing all `// clang-format off` and `// clang-format on` comments, effectively enabling lines between those comments to be formatted by Clang-Format.