### PR TITLE
Bump CTest Action to Version 1.0.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,4 +36,4 @@ jobs:
           git diff --exit-code HEAD
 
       - name: Run tests
-        uses: threeal/ctest-action@main
+        uses: threeal/ctest-action@v1.0.0


### PR DESCRIPTION
This pull request simply bumps the [CTest Action](https://github.com/threeal/ctest-action) to the [version 1.0.0](https://github.com/threeal/ctest-action/releases/tag/v1.0.0).