### PR TITLE
Specify LeetTest Version to Use

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Test Solutions
         working-directory: problems
-        run: npx --yes leettest
+        run: npx --yes leettest@0.1.0
 
   test-old-solutions:
     name: Test Old Solutions


### PR DESCRIPTION
This pull request resolves #731 by simply modifying the Test Solutions step of the Test Solutions job in the CI workflow to specify the LeetTest version to be used.