### PR TITLE
Bump LeetTest to Version 0.2.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,7 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Test Solutions
-        working-directory: problems
-        run: npx --yes leettest@0.2.0
+        run: npx --yes leettest@0.2.0 problems/**/solution.cpp
 
   test-old-solutions:
     name: Test Old Solutions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
 
       - name: Test Solutions
         working-directory: problems
-        run: npx --yes leettest@0.1.0
+        run: npx --yes leettest@0.2.0
 
   test-old-solutions:
     name: Test Old Solutions

--- a/problems/0009/test.yaml
+++ b/problems/0009/test.yaml
@@ -2,9 +2,10 @@ cpp:
   function:
     name: isPalindrome
     inputs:
-      - name: x
-        type: int
-    output: bool
+      - type: int
+        value: x
+    output:
+      type: bool
 
 cases:
   - name: example 1

--- a/problems/0343/test.yaml
+++ b/problems/0343/test.yaml
@@ -2,9 +2,10 @@ cpp:
   function:
     name: integerBreak
     inputs:
-      - name: n
-        type: int
-    output: int
+      - type: int
+        value: n
+    output:
+      type: int
 
 cases:
   - name: example 1

--- a/problems/0576/test.yaml
+++ b/problems/0576/test.yaml
@@ -2,17 +2,18 @@ cpp:
   function:
     name: findPaths
     inputs:
-      - name: m
-        type: int
-      - name: n
-        type: int
-      - name: maxMove
-        type: int
-      - name: startRow
-        type: int
-      - name: startColumn
-        type: int
-    output: int
+      - type: int
+        value: m
+      - type: int
+        value: n
+      - type: int
+        value: maxMove
+      - type: int
+        value: startRow
+      - type: int
+        value: startColumn
+    output:
+      type: int
 
 cases:
   - name: example 1

--- a/problems/1269/test.yaml
+++ b/problems/1269/test.yaml
@@ -2,11 +2,12 @@ cpp:
   function:
     name: numWays
     inputs:
-      - name: steps
-        type: int
-      - name: arrLen
-        type: int
-    output: int
+      - type: int
+        value: steps
+      - type: int
+        value: arrLen
+    output:
+      type: int
 
 cases:
   - name: example 1


### PR DESCRIPTION
This pull request introduces the following changes:
- Bumps LeetTest to version [0.2.0](https://github.com/threeal/leettest/releases/tag/v0.2.0).
- Updates test schemas to align with version 0.2.0 of LeetTest.
- Uses the `files` argument to specify solutions to test in the `leettest` command.