### PR TITLE
Solve Problem 623. Add One Row to Tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [576. Out of Boundary Paths](https://leetcode.com/problems/out-of-boundary-paths/) | Medium | [C++](./problems/0576/solution.cpp) |
 | [606. Construct String from Binary Tree](https://leetcode.com/problems/construct-string-from-binary-tree/) | Easy | [C++](./old-problems/0606/solution.cpp) |
 | [621. Task Scheduler](https://leetcode.com/problems/task-scheduler/) | Medium | [C](./old-problems/0621/c/solution.c) [C++](./old-problems/0621/solution.cpp) |
+| [623. Add One Row to Tree](https://leetcode.com/problems/add-one-row-to-tree/) | Medium | [C++](./old-problems/0623/solution.cpp) |
 | [645. Set Mismatch](https://leetcode.com/problems/set-mismatch/) | Easy | [C](./old-problems/0645/c/solution.c) [C++](./old-problems/0645/solution.cpp) |
 | [647. Palindromic Substrings](https://leetcode.com/problems/palindromic-substrings/) | Medium | [C](./old-problems/0647/c/solution.c) [C++](./old-problems/0647/solution.cpp) |
 | [661. Image Smoother](https://leetcode.com/problems/image-smoother/) | Easy | [C++](./old-problems/0661/solution.cpp) |

--- a/old-problems/0623/CMakeLists.txt
+++ b/old-problems/0623/CMakeLists.txt
@@ -1,0 +1,6 @@
+get_dir_name(id)
+
+add_executable(test-${id} test.cpp)
+target_link_libraries(test-${id} PRIVATE Catch2::Catch2WithMain)
+
+catch_discover_tests(test-${id})

--- a/old-problems/0623/solution.cpp
+++ b/old-problems/0623/solution.cpp
@@ -1,0 +1,8 @@
+class Solution {
+ public:
+  TreeNode* addOneRow(TreeNode* root, int val, int depth) {
+    (void)val;
+    (void)depth;
+    return root;
+  }
+};

--- a/old-problems/0623/solution.cpp
+++ b/old-problems/0623/solution.cpp
@@ -1,8 +1,19 @@
 class Solution {
  public:
   TreeNode* addOneRow(TreeNode* root, int val, int depth) {
-    (void)val;
-    (void)depth;
-    return root;
+    switch (depth) {
+      case 1:
+        return new TreeNode(val, root, nullptr);
+
+      case 2:
+        root->left = new TreeNode(val, root->left, nullptr);
+        root->right = new TreeNode(val, nullptr, root->right);
+        return root;
+
+      default:
+        if (root->left != nullptr) addOneRow(root->left, val, depth - 1);
+        if (root->right != nullptr) addOneRow(root->right, val, depth - 1);
+        return root;
+    }
   }
 };

--- a/old-problems/0623/test.cpp
+++ b/old-problems/0623/test.cpp
@@ -1,0 +1,80 @@
+struct TreeNode {
+  int val;
+  TreeNode* left;
+  TreeNode* right;
+
+  TreeNode() : val(0), left(nullptr), right(nullptr) {}
+  TreeNode(int x) : val(x), left(nullptr), right(nullptr) {}
+  TreeNode(int x, TreeNode* left, TreeNode* right) : val(x), left(left), right(right) {}
+};
+
+// clang-format off
+#include "solution.cpp"
+// clang-format on
+
+#include <catch2/catch_test_macros.hpp>
+#include <optional>
+#include <queue>
+#include <vector>
+
+std::vector<std::optional<int>> to_list(TreeNode* root) {
+  if (root == nullptr) return {};
+
+  std::vector<std::optional<int>> list{};
+
+  std::queue<TreeNode*> nodes{};
+  nodes.push(root);
+
+  while (!nodes.empty()) {
+    if (nodes.front() == nullptr) {
+      list.push_back(std::nullopt);
+    } else {
+      list.push_back(nodes.front()->val);
+      nodes.push(nodes.front()->left);
+      nodes.push(nodes.front()->right);
+    }
+    nodes.pop();
+  }
+
+  while (!list.back()) {
+    list.pop_back();
+  }
+
+  return list;
+}
+
+TreeNode* from_list(const std::vector<std::optional<int>>& list) {
+  if (list.empty()) return nullptr;
+
+  auto root{new TreeNode(*list[0])};
+
+  std::queue<TreeNode**> children{};
+  children.push(&(root->left));
+  children.push(&(root->right));
+
+  for (std::size_t i{1}; i < list.size(); ++i) {
+    if (list[i]) {
+      auto node{new TreeNode(*list[i])};
+      *children.front() = node;
+      children.push(&(node->left));
+      children.push(&(node->right));
+    }
+    children.pop();
+  }
+
+  return root;
+}
+
+TEST_CASE("623. Add One Row to Tree") {
+  SECTION("Example 1") {
+    auto res = Solution{}.addOneRow(from_list({4, 2, 6, 3, 1, 5}), 1, 2);
+    std::vector<std::optional<int>> expected{4, 1, 1, 2, std::nullopt, std::nullopt, 6, 3, 1, 5};
+    REQUIRE(to_list(res) == expected);
+  }
+
+  SECTION("Example 1") {
+    auto res = Solution{}.addOneRow(from_list({4, 2, std::nullopt, 3, 1}), 1, 3);
+    std::vector<std::optional<int>> expected{4, 2, std::nullopt, 1, 1, 3, std::nullopt, std::nullopt, 1};
+    REQUIRE(to_list(res) == expected);
+  }
+}

--- a/package-lock
+++ b/package-lock
@@ -16,6 +16,8 @@ CPMDeclarePackage(Catch2
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
   EXCLUDE_FROM_ALL YES
+  OPTIONS
+    "CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER ON"
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake


### PR DESCRIPTION
This pull request resolves #763 by solving the problem [623. Add One Row to Tree](https://leetcode.com/problems/add-one-row-to-tree/) in the C++ language. Additionally, it enables the `CATCH_CONFIG_ENABLE_OPTIONAL_STRINGMAKER` option in Catch2 to allow assertions to display the content of an `std::optional` type.