### PR TITLE
Bump CheckWarning.cmake to Version 2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(CMAKE_CXX_STANDARD 20)
 include(cmake/CPM.cmake)
 
 cpmgetpackage(CheckWarning.cmake)
+include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
 add_check_warning()
 
 cpmgetpackage(Format.cmake)

--- a/package-lock
+++ b/package-lock
@@ -21,7 +21,7 @@ CPMDeclarePackage(Catch2
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 2.0.1
+  VERSION 2.1.1
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request simply bumps the CheckWarning.cmake to version [2.1.1](https://github.com/threeal/CheckWarning.cmake/releases/tag/v2.1.1).