### PR TITLE
Utilize LeetTest Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@v4.1.2
 
       - name: Test Solutions
-        run: npx --yes leettest@0.2.0 problems/**/solution.cpp
+        uses: threeal/leettest-action@v0.2.0
+        with:
+          files: problems/**/solution.cpp
 
   test-old-solutions:
     name: Test Old Solutions


### PR DESCRIPTION
This pull request resolves #798 by utilizing the [LeetTest Action](https://github.com/threeal/leettest-action) in the CI workflow, replacing the direct call to the [leettest](https://www.npmjs.com/package/leettest) package with `npx`.