### PR TITLE
Solve Problem 1442. Count Triplets That Can Form Two Arrays of Equal XOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1425. Constrained Subsequence Sum](https://leetcode.com/problems/constrained-subsequence-sum) | Hard | [C++](./problems/1425/solution.cpp) |
 | [1436. Destination City](https://leetcode.com/problems/destination-city/) | Easy | [C++](./problems/1436/solution.cpp) |
 | [1441. Build an Array With Stack Operations](https://leetcode.com/problems/build-an-array-with-stack-operations) | Medium | [C++](./problems/1441/solution.cpp) |
+| [1442. Count Triplets That Can Form Two Arrays of Equal XOR](https://leetcode.com/problems/count-triplets-that-can-form-two-arrays-of-equal-xor/) | Medium | [C++](./old-problems/1442/solution.cpp) |
 | [1457. Pseudo-Palindromic Paths in a Binary Tree](https://leetcode.com/problems/pseudo-palindromic-paths-in-a-binary-tree/) | Medium | [C++](./old-problems/1457/solution.cpp) |
 | [1458. Max Dot Product of Two Subsequences](https://leetcode.com/problems/max-dot-product-of-two-subsequences) | Hard | [C++](./problems/1458/solution.cpp) |
 | [1464. Maximum Product of Two Elements in an Array](https://leetcode.com/problems/maximum-product-of-two-elements-in-an-array/) | Easy | [C](./old-problems/1464/c/solution.c) [C++](./old-problems/1464/solution.cpp) |

--- a/old-problems/1442/CMakeLists.txt
+++ b/old-problems/1442/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1442/solution.cpp
+++ b/old-problems/1442/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int countTriplets(std::vector<int>& arr) {
+    return arr.size();
+  }
+};

--- a/old-problems/1442/solution.cpp
+++ b/old-problems/1442/solution.cpp
@@ -3,6 +3,14 @@
 class Solution {
  public:
   int countTriplets(std::vector<int>& arr) {
-    return arr.size();
+    int count{0};
+    for (int k = arr.size() - 1; k > 0; --k) {
+      int sum{arr[k]};
+      for (int i{k - 1}; i >= 0; --i) {
+        sum ^= arr[i];
+        if (sum == 0) count += k - i;
+      }
+    }
+    return count;
   }
 };

--- a/old-problems/1442/test.yaml
+++ b/old-problems/1442/test.yaml
@@ -1,0 +1,21 @@
+name: 1442. Count Triplets That Can Form Two Arrays of Equal XOR
+
+types:
+  inputs:
+    arr: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: countTriplets
+
+test_cases:
+  example_1:
+    inputs:
+      arr: [2, 3, 1, 6, 7]
+    output: 4
+
+  example_2:
+    inputs:
+      arr: [1, 1, 1, 1, 1]
+    output: 10


### PR DESCRIPTION
This pull request resolves #966 by solving the problem [1442. Count Triplets That Can Form Two Arrays of Equal XOR](https://leetcode.com/problems/count-triplets-that-can-form-two-arrays-of-equal-xor/) in the C++ language.