### PR TITLE
Bump CPM.cmake to Version 0.40.0

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.39.0)
-set(CPM_HASH_SUM 66639bcac9dd2907b2918de466783554c1334446b9874e90d38e3778d404c2ef)
+set(CPM_DOWNLOAD_VERSION 0.40.0)
+set(CPM_HASH_SUM 6c9866a0aa0f804a36fe8c3866fb8a2c)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")
@@ -17,7 +17,7 @@ endif()
 get_filename_component(CPM_DOWNLOAD_LOCATION ${CPM_DOWNLOAD_LOCATION} ABSOLUTE)
 
 file(DOWNLOAD https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_DOWNLOAD_VERSION}/CPM.cmake
-     ${CPM_DOWNLOAD_LOCATION} EXPECTED_HASH SHA256=${CPM_HASH_SUM})
+     ${CPM_DOWNLOAD_LOCATION} EXPECTED_MD5 ${CPM_HASH_SUM})
 
 include(${CPM_DOWNLOAD_LOCATION})
 cpmusepackagelock(package-lock)


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.40.0](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.40.0).