### PR TITLE
Solve Problem 1579. Remove Max Number of Edges to Keep Graph Fully Traversable in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1552. Magnetic Force Between Two Balls](https://leetcode.com/problems/magnetic-force-between-two-balls/) | Medium | [C++](./old-problems/1552/solution.cpp) |
 | [1561. Maximum Number of Coins You Can Get](https://leetcode.com/problems/maximum-number-of-coins-you-can-get/) | Medium | [C](./old-problems/1561/c/solution.c) [C++](./old-problems/1561/solution.cpp) |
 | [1578. Minimum Time to Make Rope Colorful](https://leetcode.com/problems/minimum-time-to-make-rope-colorful/) | Medium | [C++](./old-problems/1578/solution.cpp) |
-| [1579. Remove Max Number of Edges to Keep Graph Fully Traversable](https://leetcode.com/problems/remove-max-number-of-edges-to-keep-graph-fully-traversable/) | Hard | [C++](./old-problems/1579/solution.cpp) |
+| [1579. Remove Max Number of Edges to Keep Graph Fully Traversable](https://leetcode.com/problems/remove-max-number-of-edges-to-keep-graph-fully-traversable/) | Hard | [C](./old-problems/1579/c/solution.c) [C++](./old-problems/1579/solution.cpp) |
 | [1582. Special Positions in a Binary Matrix](https://leetcode.com/problems/special-positions-in-a-binary-matrix/) | Easy | [C](./old-problems/1582/c/solution.c) [C++](./old-problems/1582/solution.cpp) |
 | [1600. Throne Inheritance](https://leetcode.com/problems/throne-inheritance/) | Medium | [C++](./old-problems/1600/solution.cpp) |
 | [1608. Special Array With X Elements Greater Than or Equal X](https://leetcode.com/problems/special-array-with-x-elements-greater-than-or-equal-x/) | Easy | [C](./old-problems/1608/c/solution.c) [C++](./old-problems/1608/solution.cpp) |

--- a/old-problems/1579/CMakeLists.txt
+++ b/old-problems/1579/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1579/c/interface.cpp
+++ b/old-problems/1579/c/interface.cpp
@@ -1,0 +1,17 @@
+#include <vector>
+
+extern "C" {
+int maxNumEdgesToRemove(int n, int** edges, int edgesSize, int* edgesColSize);
+}
+
+int solution_c(int n, std::vector<std::vector<int>> edges) {
+  std::vector<int*> edgesDatas(edges.size());
+  std::vector<int> edgesSizes(edges.size());
+  for (int i = edges.size() - 1; i >= 0; --i) {
+    edgesDatas[i] = edges[i].data();
+    edgesSizes[i] = edges[i].size();
+  }
+
+  return maxNumEdgesToRemove(
+      n, edgesDatas.data(), edgesDatas.size(), edgesSizes.data());
+}

--- a/old-problems/1579/c/solution.c
+++ b/old-problems/1579/c/solution.c
@@ -1,7 +1,88 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct unions_t {
+  int components;
+  int* parentOf;
+};
+
+void unionsInit(struct unions_t* unions, int n) {
+  unions->components = n;
+  unions->parentOf = malloc((n + 1) * sizeof(int));
+  for (int i = n; i >= 0; --i) {
+    unions->parentOf[i] = i;
+  }
+}
+
+void unionsCopy(struct unions_t* dst, const struct unions_t* src, int n) {
+  dst->components = src->components;
+  dst->parentOf = malloc((n + 1) * sizeof(int));
+  memcpy(dst->parentOf, src->parentOf, (n + 1) * sizeof(int));
+}
+
+void unionsCleanup(const struct unions_t* unions) {
+  free(unions->parentOf);
+}
+
+int unionsFindRootOf(struct unions_t* unions, int i) {
+  if (unions->parentOf[i] != i)
+    unions->parentOf[i] = unionsFindRootOf(unions, unions->parentOf[i]);
+  return unions->parentOf[i];
+}
+
+bool unionsUnite(struct unions_t* unions, int a, int b) {
+  const int rootA = unionsFindRootOf(unions, a);
+  const int rootB = unionsFindRootOf(unions, b);
+  if (rootA == rootB) return false;
+  if (rootA < rootB) {
+    unions->parentOf[rootA] = rootB;
+  } else {
+    unions->parentOf[rootB] = rootA;
+  }
+  --unions->components;
+  return true;
+}
+
+bool unionsIsAllConnected(struct unions_t* unions) {
+  return unions->components == 1;
+}
+
 int maxNumEdgesToRemove(int n, int** edges, int edgesSize, int* edgesColSize) {
-  (void)n;
-  (void)edges;
-  (void)edgesSize;
   (void)edgesColSize;
-  return 0;
+
+  int requiredEdges = 0;
+
+  struct unions_t alice;
+  unionsInit(&alice, n);
+
+  for (int i = edgesSize - 1; i >= 0; --i) {
+    if (edges[i][0] == 3 && unionsUnite(&alice, edges[i][1], edges[i][2])) {
+      ++requiredEdges;
+    }
+  }
+
+  struct unions_t bob;
+  unionsCopy(&bob, &alice, n);
+
+  for (int i = edgesSize - 1; i >= 0; --i) {
+    switch (edges[i][0]) {
+      case 1:
+        if (unionsUnite(&alice, edges[i][1], edges[i][2])) ++requiredEdges;
+        break;
+
+      case 2:
+        if (unionsUnite(&bob, edges[i][1], edges[i][2])) ++requiredEdges;
+        break;
+    }
+  }
+
+  const int output = unionsIsAllConnected(&alice) && unionsIsAllConnected(&bob)
+      ? edgesSize - requiredEdges
+      : -1;
+
+  unionsCleanup(&alice);
+  unionsCleanup(&bob);
+
+  return output;
 }

--- a/old-problems/1579/c/solution.c
+++ b/old-problems/1579/c/solution.c
@@ -1,0 +1,7 @@
+int maxNumEdgesToRemove(int n, int** edges, int edgesSize, int* edgesColSize) {
+  (void)n;
+  (void)edges;
+  (void)edgesSize;
+  (void)edgesColSize;
+  return 0;
+}

--- a/old-problems/1579/test.yaml
+++ b/old-problems/1579/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: maxNumEdgesToRemove
 


### PR DESCRIPTION
This pull request resolves #1237 by solving the problem [1579. Remove Max Number of Edges to Keep Graph Fully Traversable](https://leetcode.com/problems/remove-max-number-of-edges-to-keep-graph-fully-traversable/) in C. It implements the same solution as the C++ solution in #1162 to find the maximum number of edges to remove.