### PR TITLE
Solve Problem 1353. Maximum Number of Events That Can Be Attended

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1337. The K Weakest Rows in a Matrix](https://leetcode.com/problems/the-k-weakest-rows-in-a-matrix) | Easy | [C++](./problems/1337/solution.cpp) |
 | [1347. Minimum Number of Steps to Make Two Strings Anagram](https://leetcode.com/problems/minimum-number-of-steps-to-make-two-strings-anagram/) | Medium | [C](./old-problems/1347/c/solution.c) [C++](./old-problems/1347/solution.cpp) |
 | [1348. Tweet Counts Per Frequency](https://leetcode.com/problems/tweet-counts-per-frequency/) | Medium | [C++](./old-problems/1348/solution.cpp) |
+| [1353. Maximum Number of Events That Can Be Attended](https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended/) | Medium | [C++](./old-problems/1353/solution.cpp) |
 | [1356. Sort Integers by The Number of 1 Bits](https://leetcode.com/problems/sort-integers-by-the-number-of-1-bits) | Easy | [C++](./problems/1356/solution.cpp) |
 | [1357. Apply Discount Every n Orders](https://leetcode.com/problems/apply-discount-every-n-orders/) | Medium | [C++](./old-problems/1357/solution.cpp) |
 | [1361. Validate Binary Tree Nodes](https://leetcode.com/problems/validate-binary-tree-nodes) | Medium | [C](./old-problems/1361/c/solution.c) [C++](./old-problems/1361/solution.cpp) |

--- a/old-problems/1353/CMakeLists.txt
+++ b/old-problems/1353/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1353/solution.cpp
+++ b/old-problems/1353/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int maxEvents(std::vector<std::vector<int>>& events) {
+    return events.size();
+  }
+};

--- a/old-problems/1353/solution.cpp
+++ b/old-problems/1353/solution.cpp
@@ -1,8 +1,38 @@
+#include <algorithm>
+#include <queue>
 #include <vector>
 
 class Solution {
  public:
   int maxEvents(std::vector<std::vector<int>>& events) {
-    return events.size();
+    std::sort(events.begin(), events.end(), [](const auto& a, const auto& b) {
+      return a[0] < b[0];
+    });
+
+    int count{0};
+    int day{0};
+    auto eventsIt = events.begin();
+    std::priority_queue<int, std::vector<int>, std::greater<int>> eventEnds{};
+
+    while (eventsIt != events.end() || !eventEnds.empty()) {
+      if (eventEnds.empty() && day < (*eventsIt)[0]) {
+        day = (*eventsIt)[0];
+      }
+
+      while (eventsIt != events.end() && (*eventsIt)[0] == day) {
+        eventEnds.push((*eventsIt)[1]);
+        ++eventsIt;
+      }
+
+      eventEnds.pop();
+      ++count;
+      ++day;
+
+      while (!eventEnds.empty() && eventEnds.top() < day) {
+        eventEnds.pop();
+      }
+    }
+
+    return count;
   }
 };

--- a/old-problems/1353/test.yaml
+++ b/old-problems/1353/test.yaml
@@ -20,6 +20,11 @@ test_cases:
       events: [[1, 2], [2, 3], [3, 4], [1, 2]]
     output: 4
 
+  test_case_31:
+    inputs:
+      events: [[1, 5], [1, 5], [1, 5], [2, 3], [2, 3]]
+    output: 5
+
   test_case_34:
     inputs:
       events: [[1, 2], [1, 2], [3, 3], [1, 5], [1, 5]]

--- a/old-problems/1353/test.yaml
+++ b/old-problems/1353/test.yaml
@@ -19,3 +19,8 @@ test_cases:
     inputs:
       events: [[1, 2], [2, 3], [3, 4], [1, 2]]
     output: 4
+
+  test_case_34:
+    inputs:
+      events: [[1, 2], [1, 2], [3, 3], [1, 5], [1, 5]]
+    output: 5

--- a/old-problems/1353/test.yaml
+++ b/old-problems/1353/test.yaml
@@ -1,0 +1,21 @@
+name: 1353. Maximum Number of Events That Can Be Attended
+
+types:
+  inputs:
+    events: std::vector<std::vector<int>>
+  output: int
+
+solutions:
+  cpp:
+    function: maxEvents
+
+test_cases:
+  example_1:
+    inputs:
+      events: [[1, 2], [2, 3], [3, 4]]
+    output: 3
+
+  example_2:
+    inputs:
+      events: [[1, 2], [2, 3], [3, 4], [1, 2]]
+    output: 4

--- a/old-problems/1353/test.yaml
+++ b/old-problems/1353/test.yaml
@@ -24,3 +24,8 @@ test_cases:
     inputs:
       events: [[1, 2], [1, 2], [3, 3], [1, 5], [1, 5]]
     output: 5
+
+  test_case_41:
+    inputs:
+      events: [[1, 10], [2, 2], [2, 2], [2, 2], [2, 2]]
+    output: 2


### PR DESCRIPTION
This pull request resolves #1332 by solving the problem [1353. Maximum Number of Events That Can Be Attended](https://leetcode.com/problems/maximum-number-of-events-that-can-be-attended/) in C++. 

It solves the problem by first sorting the events by the starting date and then iterating through each day until all the events have ended. For each day, store each event that starts in a priority queue to attend the one that will end soonest.