### PR TITLE
Solve Problem 1247. Minimum Swaps to Make Strings Equal

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1232. Check If It Is a Straight Line](https://leetcode.com/problems/check-if-it-is-a-straight-line) | Easy | [C++](./problems/1232/solution.cpp) |
 | [1235. Maximum Profit in Job Scheduling](https://leetcode.com/problems/maximum-profit-in-job-scheduling/) | Hard | [C++](./problems/1235/solution.cpp) |
 | [1239. Maximum Length of a Concatenated String with Unique Characters](https://leetcode.com/problems/maximum-length-of-a-concatenated-string-with-unique-characters/) | Medium | [C](./old-problems/1239/c/solution.c) [C++](./old-problems/1239/solution.cpp) |
+| [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) | Medium | [C++](./old-problems/1247/solution.cpp) |
 | [1248. Count Number of Nice Subarrays](https://leetcode.com/problems/count-number-of-nice-subarrays/) | Medium | [C](./old-problems/1248/c/solution.c) [C++](./old-problems/1248/solution.cpp) |
 | [1253. Reconstruct a 2-Row Binary Matrix](https://leetcode.com/problems/reconstruct-a-2-row-binary-matrix/) | Medium | [C](./old-problems/1253/c/solution.c) [C++](./old-problems/1253/solution.cpp) |
 | [1255. Maximum Score Words Formed by Letters](https://leetcode.com/problems/maximum-score-words-formed-by-letters/) | Hard | [C](./old-problems/1255/c/solution.c) [C++](./old-problems/1255/solution.cpp) |

--- a/old-problems/1247/CMakeLists.txt
+++ b/old-problems/1247/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1247/solution.cpp
+++ b/old-problems/1247/solution.cpp
@@ -1,0 +1,8 @@
+#include <string>
+
+class Solution {
+ public:
+  int minimumSwap(std::string s1, std::string s2) {
+    return s1.size() < s2.size() ? s1.size() : s2.size();
+  }
+};

--- a/old-problems/1247/solution.cpp
+++ b/old-problems/1247/solution.cpp
@@ -3,6 +3,19 @@
 class Solution {
  public:
   int minimumSwap(std::string s1, std::string s2) {
-    return s1.size() < s2.size() ? s1.size() : s2.size();
+    int x1{0}, y1{0};
+    for (int i = s1.size() - 1; i >= 0; --i) {
+      if (s1[i] != s2[i]) {
+        if (s1[i] == 'x') {
+          ++x1;
+        } else {
+          ++y1;
+        }
+      }
+    }
+
+    return x1 % 2 == 0
+        ? (y1 % 2 == 0 ? (x1 + y1) / 2 : -1)
+        : (y1 % 2 == 0 ? -1 : (x1 + y1) / 2 + 1);
   }
 };

--- a/old-problems/1247/test.yaml
+++ b/old-problems/1247/test.yaml
@@ -1,0 +1,30 @@
+name: 1247. Minimum Swaps to Make Strings Equal
+
+types:
+  inputs:
+    s1: std::string
+    s2: std::string
+  output: int
+
+solutions:
+  cpp:
+    function: minimumSwap
+
+test_cases:
+  example_1:
+    inputs:
+      s1: xx
+      s2: yy
+    output: 1
+
+  example_2:
+    inputs:
+      s1: xy
+      s2: yx
+    output: 2
+
+  example_3:
+    inputs:
+      s1: xx
+      s2: xy
+    output: -1


### PR DESCRIPTION
This pull request resolves #1530 by solving the problem [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) in C++. It solves the problem by counting `x` and `y` characters and calculating the minimum swaps accordingly.