### PR TITLE
Solve Problem 1247. Minimum Swaps to Make Strings Equal in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1232. Check If It Is a Straight Line](https://leetcode.com/problems/check-if-it-is-a-straight-line) | Easy | [C++](./problems/1232/solution.cpp) |
 | [1235. Maximum Profit in Job Scheduling](https://leetcode.com/problems/maximum-profit-in-job-scheduling/) | Hard | [C++](./problems/1235/solution.cpp) |
 | [1239. Maximum Length of a Concatenated String with Unique Characters](https://leetcode.com/problems/maximum-length-of-a-concatenated-string-with-unique-characters/) | Medium | [C](./old-problems/1239/c/solution.c) [C++](./old-problems/1239/solution.cpp) |
-| [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) | Medium | [C++](./old-problems/1247/solution.cpp) |
+| [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) | Medium | [C](./old-problems/1247/c/solution.c) [C++](./old-problems/1247/solution.cpp) |
 | [1248. Count Number of Nice Subarrays](https://leetcode.com/problems/count-number-of-nice-subarrays/) | Medium | [C](./old-problems/1248/c/solution.c) [C++](./old-problems/1248/solution.cpp) |
 | [1253. Reconstruct a 2-Row Binary Matrix](https://leetcode.com/problems/reconstruct-a-2-row-binary-matrix/) | Medium | [C](./old-problems/1253/c/solution.c) [C++](./old-problems/1253/solution.cpp) |
 | [1255. Maximum Score Words Formed by Letters](https://leetcode.com/problems/maximum-score-words-formed-by-letters/) | Hard | [C](./old-problems/1255/c/solution.c) [C++](./old-problems/1255/solution.cpp) |

--- a/old-problems/1247/CMakeLists.txt
+++ b/old-problems/1247/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1247/c/interface.cpp
+++ b/old-problems/1247/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int minimumSwap(char* s1, char* s2);
+}
+
+int solution_c(std::string s1, std::string s2) {
+  return minimumSwap(s1.data(), s2.data());
+}

--- a/old-problems/1247/c/solution.c
+++ b/old-problems/1247/c/solution.c
@@ -1,0 +1,5 @@
+int minimumSwap(char* s1, char* s2) {
+  (void)s1;
+  (void)s2;
+  return 0;
+}

--- a/old-problems/1247/c/solution.c
+++ b/old-problems/1247/c/solution.c
@@ -1,5 +1,18 @@
 int minimumSwap(char* s1, char* s2) {
-  (void)s1;
-  (void)s2;
-  return 0;
+  int x1 = 0, y1 = 0;
+  while (*s1 != 0) {
+    if (*s1 != *s2) {
+      if (*s1 == 'x') {
+        ++x1;
+      } else {
+        ++y1;
+      }
+    }
+    ++s1;
+    ++s2;
+  }
+
+  return x1 % 2 == 0
+      ? (y1 % 2 == 0 ? (x1 + y1) / 2 : -1)
+      : (y1 % 2 == 0 ? -1 : (x1 + y1) / 2 + 1);
 }

--- a/old-problems/1247/test.yaml
+++ b/old-problems/1247/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minimumSwap
 


### PR DESCRIPTION
This pull request resolves #1566 by solving the problem [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) in C. It solves the problem by implementing the same solution as the C++ solution to the problem implemented in #1531.