### PR TITLE
Solve Problem 2001. Number of Pairs of Interchangeable Rectangles

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1992. Find All Groups of Farmland](https://leetcode.com/problems/find-all-groups-of-farmland/) | Medium | [C](./old-problems/1992/c/solution.c) [C++](./old-problems/1992/solution.cpp) |
 | [1995. Count Special Quadruplets](https://leetcode.com/problems/count-special-quadruplets/) | Easy | [C](./old-problems/1995/c/solution.c) [C++](./old-problems/1995/solution.cpp) |
 | [2000. Reverse Prefix of Word](https://leetcode.com/problems/reverse-prefix-of-word/) | Easy | [C](./old-problems/2000/c/solution.c) [C++](./old-problems/2000/solution.cpp) |
+| [2001. Number of Pairs of Interchangeable Rectangles](https://leetcode.com/problems/number-of-pairs-of-interchangeable-rectangles/) | Medium | [C++](./old-problems/2001/solution.cpp) |
 | [2009. Minimum Number of Operations to Make Array Continuous](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-continuous) | Hard | [C++](./problems/2009/solution.cpp) |
 | [2017. Grid Game](https://leetcode.com/problems/grid-game/) | Medium | [C](./old-problems/2017/c/solution.c) [C++](./old-problems/2017/solution.cpp) |
 | [2018. Check if Word Can Be Placed In Crossword](https://leetcode.com/problems/check-if-word-can-be-placed-in-crossword/) | Medium | [C](./old-problems/2018/c/solution.c) [C++](./old-problems/2018/solution.cpp) |

--- a/old-problems/2001/CMakeLists.txt
+++ b/old-problems/2001/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/2001/solution.cpp
+++ b/old-problems/2001/solution.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+class Solution {
+ public:
+  long long interchangeableRectangles(
+      std::vector<std::vector<int>>& rectangles) {
+    return rectangles.size();
+  }
+};

--- a/old-problems/2001/solution.cpp
+++ b/old-problems/2001/solution.cpp
@@ -1,9 +1,29 @@
+#include <algorithm>
+#include <numeric>
 #include <vector>
 
 class Solution {
  public:
   long long interchangeableRectangles(
       std::vector<std::vector<int>>& rectangles) {
-    return rectangles.size();
+    for (auto& rectangle : rectangles) {
+      const int gcd{std::gcd(rectangle[0], rectangle[1])};
+      rectangle[0] /= gcd;
+      rectangle[1] /= gcd;
+    }
+
+    std::sort(rectangles.begin(), rectangles.end());
+
+    long long totalCount{0}, count{0};
+    for (std::size_t i{1}; i < rectangles.size(); ++i) {
+      if (rectangles[i][0] == rectangles[i - 1][0] &&
+          rectangles[i][1] == rectangles[i - 1][1]) {
+        totalCount += ++count;
+      } else {
+        count = 0;
+      }
+    }
+
+    return totalCount;
   }
 };

--- a/old-problems/2001/test.yaml
+++ b/old-problems/2001/test.yaml
@@ -1,0 +1,21 @@
+name: 2001. Number of Pairs of Interchangeable Rectangles
+
+types:
+  inputs:
+    rectangles: std::vector<std::vector<int>>
+  output: long long
+
+solutions:
+  cpp:
+    function: interchangeableRectangles
+
+test_cases:
+  example_1:
+    inputs:
+      rectangles: [[4, 8], [3, 6], [10, 20], [15, 30]]
+    output: 6
+
+  example_2:
+    inputs:
+      rectangles: [[4, 5], [7, 8]]
+    output: 0


### PR DESCRIPTION
This pull request resolves #1592 by solving the problem [2001. Number of Pairs of Interchangeable Rectangles](https://leetcode.com/problems/number-of-pairs-of-interchangeable-rectangles/) in C++.  It does so by first normalizing each rectangle by dividing its dimensions by their GCD, then sorting the normalized rectangles and counting the interchangeable pairs accordingly.