### PR TITLE
Bump CPM.cmake to Version 0.40.2

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.40.1)
-set(CPM_HASH_SUM a5467d77aa63a1197ea4e1644623acb7)
+set(CPM_DOWNLOAD_VERSION 0.40.2)
+set(CPM_HASH_SUM 4d51aa9dab6104fad39c5b7a692d5e1c)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.40.2](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.40.2).