### PR TITLE
Solve Problem 947. Most Stones Removed with Same Row or Column

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [935. Knight Dialer](https://leetcode.com/problems/knight-dialer/) | Easy | [C](./old-problems/0935/c/solution.c) [C++](./old-problems/0935/solution.cpp) |
 | [938. Range Sum of BST](https://leetcode.com/problems/range-sum-of-bst/) | Easy | [C++](./old-problems/0938/solution.cpp) |
 | [945. Minimum Increment to Make Array Unique](https://leetcode.com/problems/minimum-increment-to-make-array-unique/) | Medium | [C](./old-problems/0945/c/solution.c) [C++](./old-problems/0945/solution.cpp) |
+| [947. Most Stones Removed with Same Row or Column](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/) | Medium | [C++](./old-problems/0947/solution.cpp) |
 | [948. Bag of Tokens](https://leetcode.com/problems/bag-of-tokens/) | Medium | [C](./old-problems/0948/c/solution.c) [C++](./old-problems/0948/solution.cpp) |
 | [959. Regions Cut By Slashes](https://leetcode.com/problems/regions-cut-by-slashes/) | Medium | [C](./old-problems/0959/c/solution.c) [C++](./old-problems/0959/solution.cpp) |
 | [974. Subarray Sums Divisible by K](https://leetcode.com/problems/subarray-sums-divisible-by-k/) | Medium | [C](./old-problems/0974/c/solution.c) [C++](./old-problems/0974/solution.cpp) |

--- a/old-problems/0947/CMakeLists.txt
+++ b/old-problems/0947/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/0947/solution.cpp
+++ b/old-problems/0947/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int removeStones(std::vector<std::vector<int>>& stones) {
+    return stones.size();
+  }
+};

--- a/old-problems/0947/solution.cpp
+++ b/old-problems/0947/solution.cpp
@@ -1,8 +1,57 @@
+#include <unordered_map>
 #include <vector>
 
 class Solution {
  public:
   int removeStones(std::vector<std::vector<int>>& stones) {
-    return stones.size();
+    int removed{};
+
+    std::unordered_map<int, int> hParents{};
+    std::unordered_map<int, int> vParents{};
+
+    for (int i = stones.size() - 1; i >= 0; --i) {
+      const auto hIt = hParents.find(stones[i][0]);
+      const auto vIt = vParents.find(stones[i][1]);
+
+      if (hIt == hParents.end()) {
+        if (vIt == vParents.end()) {
+          hParents.emplace(stones[i][0], i);
+          vParents.emplace(stones[i][1], i);
+        } else {
+          hParents.emplace(stones[i][0], vIt->second);
+          ++removed;
+        }
+      } else {
+        if (vIt == vParents.end()) {
+          vParents.emplace(stones[i][1], hIt->second);
+          ++removed;
+        } else {
+          int hRoot = findHRoot(hParents, stones, hIt->second);
+          int vRoot = findHRoot(hParents, stones, vIt->second);
+          if (hRoot != vRoot) {
+            ++removed;
+            if (hRoot > vRoot) {
+              hParents[stones[vRoot][0]] = hRoot;
+              vParents[stones[vRoot][1]] = hRoot;
+            } else {
+              hParents[stones[hRoot][0]] = vRoot;
+              vParents[stones[hRoot][1]] = vRoot;
+            }
+          }
+          ++removed;
+        }
+      }
+    }
+
+    return removed;
+  }
+
+ private:
+  static int findHRoot(
+      std::unordered_map<int, int>& hParents,
+      const std::vector<std::vector<int>>& stones, int i) {
+    auto& parent = hParents[stones[i][0]];
+    if (parent != i) parent = findHRoot(hParents, stones, parent);
+    return parent;
   }
 };

--- a/old-problems/0947/test.yaml
+++ b/old-problems/0947/test.yaml
@@ -24,3 +24,8 @@ test_cases:
     inputs:
       stones: [[0, 0]]
     output: 0
+
+  test_case_13:
+    inputs:
+      stones: [[0, 1], [1, 2], [1, 3], [3, 3], [2, 3], [0, 2]]
+    output: 5

--- a/old-problems/0947/test.yaml
+++ b/old-problems/0947/test.yaml
@@ -29,3 +29,8 @@ test_cases:
     inputs:
       stones: [[0, 1], [1, 2], [1, 3], [3, 3], [2, 3], [0, 2]]
     output: 5
+
+  test_case_18:
+    inputs:
+      stones: [[3, 2], [0, 0], [3, 3], [2, 1], [2, 3], [2, 2], [0, 2]]
+    output: 6

--- a/old-problems/0947/test.yaml
+++ b/old-problems/0947/test.yaml
@@ -1,0 +1,26 @@
+name: 947. Most Stones Removed with Same Row or Column
+
+types:
+  inputs:
+    stones: std::vector<std::vector<int>>
+  output: int
+
+solutions:
+  cpp:
+    function: removeStones
+
+test_cases:
+  example_1:
+    inputs:
+      stones: [[0, 0], [0, 1], [1, 0], [1, 2], [2, 1], [2, 2]]
+    output: 5
+
+  example_2:
+    inputs:
+      stones: [[0, 0], [0, 2], [1, 1], [2, 0], [2, 2]]
+    output: 3
+
+  example_3:
+    inputs:
+      stones: [[0, 0]]
+    output: 0


### PR DESCRIPTION
This pull request resolves #1803 by solving the problem [947. Most Stones Removed with Same Row or Column](https://leetcode.com/problems/most-stones-removed-with-same-row-or-column/) in C++. It treats the connection between stones as a disjoint union and uses the number of disjoint unions to count the maximum number of stones that can be removed.