### PR TITLE
Bump CheckWarning.cmake to Version 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,7 @@ set(CMAKE_CXX_STANDARD 20)
 include(cmake/CPM.cmake)
 
 cpmgetpackage(CheckWarning.cmake)
-include(${CheckWarning_SOURCE_DIR}/cmake/CheckWarning.cmake)
-add_check_warning()
+add_check_warning(TREAT_WARNINGS_AS_ERRORS)
 
 cpmgetpackage(Format.cmake)
 

--- a/package-lock
+++ b/package-lock
@@ -21,7 +21,7 @@ CPMDeclarePackage(Catch2
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 2.1.1
+  VERSION 3.0.0
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request updates the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) project used by this project to version [3.0.0](https://github.com/threeal/CheckWarning.cmake/releases/tag/v3.0.0).