### PR TITLE
Solve Problem 2416. Sum of Prefix Scores of Strings in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2380. Time Needed to Rearrange a Binary String](https://leetcode.com/problems/time-needed-to-rearrange-a-binary-string/) | Medium | [C](./old-problems/2380/c/solution.c) [C++](./old-problems/2380/solution.cpp) |
 | [2385. Amount of Time for Binary Tree to Be Infected](https://leetcode.com/problems/amount-of-time-for-binary-tree-to-be-infected/) | Medium | [C++](./old-problems/2385/solution.cpp) |
 | [2391. Minimum Amount of Time to Collect Garbage](https://leetcode.com/problems/minimum-amount-of-time-to-collect-garbage/) | Medium | [C](./old-problems/2391/c/solution.c) [C++](./old-problems/2391/solution.cpp) |
-| [2416. Sum of Prefix Scores of Strings](https://leetcode.com/problems/sum-of-prefix-scores-of-strings/) | Hard | [C++](./old-problems/2416/solution.cpp) |
+| [2416. Sum of Prefix Scores of Strings](https://leetcode.com/problems/sum-of-prefix-scores-of-strings/) | Hard | [C](./old-problems/2416/c/solution.c) [C++](./old-problems/2416/solution.cpp) |
 | [2418. Sort the People](https://leetcode.com/problems/sort-the-people/) | Easy | [C](./old-problems/2418/c/solution.c) [C++](./old-problems/2418/solution.cpp) |
 | [2419. Longest Subarray With Maximum Bitwise AND](https://leetcode.com/problems/longest-subarray-with-maximum-bitwise-and/) | Medium | [C++](./old-problems/2419/solution.cpp) |
 | [2423. Remove Letter To Equalize Frequency](https://leetcode.com/problems/remove-letter-to-equalize-frequency/) | Easy | [C](./old-problems/2423/c/solution.c) [C++](./old-problems/2423/solution.cpp) |

--- a/old-problems/2416/CMakeLists.txt
+++ b/old-problems/2416/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2416/c/interface.cpp
+++ b/old-problems/2416/c/interface.cpp
@@ -1,0 +1,23 @@
+#include <cstring>
+#include <string>
+#include <vector>
+
+extern "C" {
+int* sumPrefixScores(char** words, int wordsSize, int* returnSize);
+}
+
+std::vector<int> solution_c(std::vector<std::string> words) {
+  std::vector<char*> wordsDatas(words.size());
+  for (std::size_t i{0}; i < words.size(); ++i) {
+    wordsDatas[i] = words[i].data();
+  }
+
+  int returnSize{};
+  const auto returnData = sumPrefixScores(
+      wordsDatas.data(), wordsDatas.size(), &returnSize);
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/2416/c/solution.c
+++ b/old-problems/2416/c/solution.c
@@ -1,0 +1,6 @@
+int* sumPrefixScores(char** words, int wordsSize, int* returnSize) {
+  (void)words;
+  (void)wordsSize;
+  *returnSize = 0;
+  return 0;
+}

--- a/old-problems/2416/test.yaml
+++ b/old-problems/2416/test.yaml
@@ -6,6 +6,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: sumPrefixScores
 


### PR DESCRIPTION
This pull request resolves #2034 by solving the problem [2416. Sum of Prefix Scores of Strings](https://leetcode.com/problems/sum-of-prefix-scores-of-strings/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #1956.