### PR TITLE
Solve Problem 2491. Divide Players Into Teams of Equal Skill in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2486. Append Characters to String to Make Subsequence](https://leetcode.com/problems/append-characters-to-string-to-make-subsequence/) | Medium | [C](./old-problems/2486/c/solution.c) [C++](./old-problems/2486/solution.cpp) |
 | [2487. Remove Nodes From Linked List](https://leetcode.com/problems/remove-nodes-from-linked-list/) | Medium | [C++](./old-problems/2487/solution.cpp) |
 | [2490. Circular Sentence](https://leetcode.com/problems/circular-sentence/) | Easy | [C](./old-problems/2490/c/solution.c) [C++](./old-problems/2490/solution.cpp) |
-| [2491. Divide Players Into Teams of Equal Skill](https://leetcode.com/problems/divide-players-into-teams-of-equal-skill/) | Medium | [C++](./old-problems/2491/solution.cpp) |
+| [2491. Divide Players Into Teams of Equal Skill](https://leetcode.com/problems/divide-players-into-teams-of-equal-skill/) | Medium | [C](./old-problems/2491/c/solution.c) [C++](./old-problems/2491/solution.cpp) |
 | [2497. Maximum Star Sum of a Graph](https://leetcode.com/problems/maximum-star-sum-of-a-graph/) | Medium | [C++](./old-problems/2497/solution.cpp) |
 | [2511. Maximum Enemy Forts That Can Be Captured](https://leetcode.com/problems/maximum-enemy-forts-that-can-be-captured/) | Easy | [C](./old-problems/2511/c/solution.c) [C++](./old-problems/2511/solution.cpp) |
 | [2525. Categorize Box According to Criteria](https://leetcode.com/problems/categorize-box-according-to-criteria/) | Easy | [C](./old-problems/2525/c/solution.c) [C++](./old-problems/2525/solution.cpp) |

--- a/old-problems/2491/CMakeLists.txt
+++ b/old-problems/2491/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2491/c/interface.cpp
+++ b/old-problems/2491/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+long long dividePlayers(int* skill, int skillSize);
+}
+
+long long solution_c(std::vector<int> skill) {
+  return dividePlayers(skill.data(), skill.size());
+}

--- a/old-problems/2491/c/solution.c
+++ b/old-problems/2491/c/solution.c
@@ -1,3 +1,18 @@
+#include <stdlib.h>
+
+int compare(const void* a, const void* b) {
+  return *(int*)a - *(int*)b;
+}
+
 long long dividePlayers(int* skill, int skillSize) {
-  return skill[skillSize - 1];
+  qsort(skill, skillSize, sizeof(int), compare);
+  const int teamSkill = skill[0] + skill[skillSize - 1];
+
+  long long chemistry = 0;
+  for (int l = 0, r = skillSize - 1; l < r; ++l, --r) {
+    if (skill[l] + skill[r] != teamSkill) return -1;
+    chemistry += skill[l] * skill[r];
+  }
+
+  return chemistry;
 }

--- a/old-problems/2491/c/solution.c
+++ b/old-problems/2491/c/solution.c
@@ -1,0 +1,3 @@
+long long dividePlayers(int* skill, int skillSize) {
+  return skill[skillSize - 1];
+}

--- a/old-problems/2491/test.yaml
+++ b/old-problems/2491/test.yaml
@@ -6,6 +6,7 @@ types:
   output: long long
 
 solutions:
+  c:
   cpp:
     function: dividePlayers
 


### PR DESCRIPTION
This pull request resolves #2056 by solving the problem [2491. Divide Players Into Teams of Equal Skill](https://leetcode.com/problems/divide-players-into-teams-of-equal-skill/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #1991.