### PR TITLE
Solve Problem 921. Minimum Add to Make Parentheses Valid in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [908. Smallest Range I](https://leetcode.com/problems/smallest-range-i/) | Easy | [C](./old-problems/0908/c/solution.c) [C++](./old-problems/0908/solution.cpp) |
 | [909. Snakes and Ladders](https://leetcode.com/problems/snakes-and-ladders/) | Medium | [C](./old-problems/0909/c/solution.c) [C++](./old-problems/0909/solution.cpp) |
 | [912. Sort an Array](https://leetcode.com/problems/sort-an-array/) | Medium | [C](./old-problems/0912/c/solution.c) [C++](./old-problems/0912/solution.cpp) |
-| [921. Minimum Add to Make Parentheses Valid](https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/) | Medium | [C++](./old-problems/0921/solution.cpp) |
+| [921. Minimum Add to Make Parentheses Valid](https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/) | Medium | [C](./old-problems/0921/c/solution.c) [C++](./old-problems/0921/solution.cpp) |
 | [925. Long Pressed Name](https://leetcode.com/problems/long-pressed-name/) | Easy | [C](./old-problems/0925/c/solution.c) [C++](./old-problems/0925/solution.cpp) |
 | [929. Unique Email Addresses](https://leetcode.com/problems/unique-email-addresses/) | Easy | [C](./old-problems/0929/c/solution.c) [C++](./old-problems/0929/solution.cpp) |
 | [930. Binary Subarrays With Sum](https://leetcode.com/problems/binary-subarrays-with-sum/) | Medium | [C++](./problems/0930/solution.cpp) |

--- a/old-problems/0921/CMakeLists.txt
+++ b/old-problems/0921/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/0921/c/interface.cpp
+++ b/old-problems/0921/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int minAddToMakeValid(char* s);
+}
+
+int solution_c(std::string s) {
+  return minAddToMakeValid(s.data());
+}

--- a/old-problems/0921/c/solution.c
+++ b/old-problems/0921/c/solution.c
@@ -1,0 +1,3 @@
+int minAddToMakeValid(char* s) {
+  return *s;
+}

--- a/old-problems/0921/c/solution.c
+++ b/old-problems/0921/c/solution.c
@@ -1,3 +1,17 @@
 int minAddToMakeValid(char* s) {
-  return *s;
+  int added = 0;
+  int level = 0;
+  while (*s != 0) {
+    if (*s == '(') {
+      ++level;
+    } else {
+      if (level == 0) {
+        ++added;
+      } else {
+        --level;
+      }
+    }
+    ++s;
+  }
+  return level + added;
 }

--- a/old-problems/0921/test.yaml
+++ b/old-problems/0921/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minAddToMakeValid
 


### PR DESCRIPTION
This pull request resolves #2070 by solving the problem [921. Minimum Add to Make Parentheses Valid](https://leetcode.com/problems/minimum-add-to-make-parentheses-valid/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2027.