### PR TITLE
Solve Problem 2406. Divide Intervals Into Minimum Number of Groups in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2385. Amount of Time for Binary Tree to Be Infected](https://leetcode.com/problems/amount-of-time-for-binary-tree-to-be-infected/) | Medium | [C++](./old-problems/2385/solution.cpp) |
 | [2391. Minimum Amount of Time to Collect Garbage](https://leetcode.com/problems/minimum-amount-of-time-to-collect-garbage/) | Medium | [C](./old-problems/2391/c/solution.c) [C++](./old-problems/2391/solution.cpp) |
 | [2938. Separate Black and White Balls](https://leetcode.com/problems/separate-black-and-white-balls/) | Medium | [C++](./old-problems/2938/solution.cpp) |
-| [2406. Divide Intervals Into Minimum Number of Groups](https://leetcode.com/problems/divide-intervals-into-minimum-number-of-groups/) | Medium | [C++](./old-problems/2406/solution.cpp) |
+| [2406. Divide Intervals Into Minimum Number of Groups](https://leetcode.com/problems/divide-intervals-into-minimum-number-of-groups/) | Medium | [C](./old-problems/2406/c/solution.c) [C++](./old-problems/2406/solution.cpp) |
 | [2416. Sum of Prefix Scores of Strings](https://leetcode.com/problems/sum-of-prefix-scores-of-strings/) | Hard | [C++](./old-problems/2416/solution.cpp) |
 | [2418. Sort the People](https://leetcode.com/problems/sort-the-people/) | Easy | [C](./old-problems/2418/c/solution.c) [C++](./old-problems/2418/solution.cpp) |
 | [2419. Longest Subarray With Maximum Bitwise AND](https://leetcode.com/problems/longest-subarray-with-maximum-bitwise-and/) | Medium | [C](./old-problems/2419/c/solution.c) [C++](./old-problems/2419/solution.cpp) |

--- a/old-problems/2406/CMakeLists.txt
+++ b/old-problems/2406/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2406/c/interface.cpp
+++ b/old-problems/2406/c/interface.cpp
@@ -1,0 +1,17 @@
+#include <vector>
+
+extern "C" {
+int minGroups(int** intervals, int intervalsSize, int* intervalsColSize);
+}
+
+int solution_c(std::vector<std::vector<int>> intervals) {
+  std::vector<int*> intervalsDatas(intervals.size());
+  std::vector<int> intervalsSizes(intervals.size());
+  for (std::size_t i{0}; i < intervals.size(); ++i) {
+    intervalsDatas[i] = intervals[i].data();
+    intervalsSizes[i] = intervals[i].size();
+  }
+
+  return minGroups(
+      intervalsDatas.data(), intervalsDatas.size(), intervalsSizes.data());
+}

--- a/old-problems/2406/c/solution.c
+++ b/old-problems/2406/c/solution.c
@@ -1,0 +1,3 @@
+int minGroups(int** intervals, int intervalsSize, int* intervalsColSize) {
+  return intervals[intervalsSize - 1][intervalsColSize[intervalsSize - 1]];
+}

--- a/old-problems/2406/c/solution.c
+++ b/old-problems/2406/c/solution.c
@@ -1,3 +1,35 @@
+#include <stdlib.h>
+
+int compare(const void* a, const void* b) {
+  return *(int*)a - *(int*)b;
+}
+
 int minGroups(int** intervals, int intervalsSize, int* intervalsColSize) {
-  return intervals[intervalsSize - 1][intervalsColSize[intervalsSize - 1]];
+  (void)intervalsColSize;
+
+  int* starts = malloc(intervalsSize * sizeof(int));
+  int* ends = malloc(intervalsSize * sizeof(int));
+
+  for (int i = 0; i < intervalsSize; ++i) {
+    starts[i] = intervals[i][0];
+    ends[i] = intervals[i][1];
+  }
+
+  qsort(starts, intervalsSize, sizeof(int), compare);
+  qsort(ends, intervalsSize, sizeof(int), compare);
+
+  int group = 0;
+  int* end = ends;
+  for (int i = 0; i < intervalsSize; ++i) {
+    if (starts[i] > *end) {
+      ++end;
+    } else {
+      ++group;
+    }
+  }
+
+  free(starts);
+  free(ends);
+
+  return group;
 }

--- a/old-problems/2406/test.yaml
+++ b/old-problems/2406/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minGroups
 


### PR DESCRIPTION
This pull request resolves #2078 by solving the problem [2406. Divide Intervals Into Minimum Number of Groups](https://leetcode.com/problems/divide-intervals-into-minimum-number-of-groups/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2045 .