### PR TITLE
Bump CheckWarning.cmake to Version 3.2.0

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -21,7 +21,7 @@ CPMDeclarePackage(Catch2
 )
 # CheckWarning.cmake
 CPMDeclarePackage(CheckWarning.cmake
-  VERSION 3.1.0
+  VERSION 3.2.0
   GITHUB_REPOSITORY threeal/CheckWarning.cmake
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request updates the [CheckWarning.cmake](https://github.com/threeal/CheckWarning.cmake) project used by this project to version [3.2.0](https://github.com/threeal/CheckWarning.cmake/releases/tag/v3.2.0).