### PR TITLE
Solve Problem 1233. Remove Sub-Folders from the Filesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1219. Path with Maximum Gold](https://leetcode.com/problems/path-with-maximum-gold/) | Medium | [C](./old-problems/1219/c/solution.c) [C++](./old-problems/1219/solution.cpp) |
 | [1220. Count Vowels Permutation](https://leetcode.com/problems/count-vowels-permutation) | Hard | [C](./old-problems/1220/c/solution.c) [C++](./old-problems/1220/solution.cpp) |
 | [1232. Check If It Is a Straight Line](https://leetcode.com/problems/check-if-it-is-a-straight-line) | Easy | [C++](./problems/1232/solution.cpp) |
+| [1233. Remove Sub-Folders from the Filesystem](https://leetcode.com/problems/remove-sub-folders-from-the-filesystem/) | Medium | [C++](./old-problems/1233/solution.cpp) |
 | [1235. Maximum Profit in Job Scheduling](https://leetcode.com/problems/maximum-profit-in-job-scheduling/) | Hard | [C++](./problems/1235/solution.cpp) |
 | [1239. Maximum Length of a Concatenated String with Unique Characters](https://leetcode.com/problems/maximum-length-of-a-concatenated-string-with-unique-characters/) | Medium | [C](./old-problems/1239/c/solution.c) [C++](./old-problems/1239/solution.cpp) |
 | [1247. Minimum Swaps to Make Strings Equal](https://leetcode.com/problems/minimum-swaps-to-make-strings-equal/) | Medium | [C](./old-problems/1247/c/solution.c) [C++](./old-problems/1247/solution.cpp) |

--- a/old-problems/1233/CMakeLists.txt
+++ b/old-problems/1233/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1233/solution.cpp
+++ b/old-problems/1233/solution.cpp
@@ -1,9 +1,24 @@
+#include <algorithm>
 #include <string>
 #include <vector>
 
 class Solution {
  public:
   std::vector<std::string> removeSubfolders(std::vector<std::string>& folder) {
-    return folder;
+    std::sort(folder.begin(), folder.end());
+
+    std::vector<std::string> output;
+    output.push_back(folder.front());
+
+    for (std::size_t i{1}; i < folder.size(); ++i) {
+      const auto& prev = output.back();
+      if (prev.size() < folder[i].size() && folder[i][prev.size()] == '/') {
+        if (folder[i].compare(0, prev.size(), prev) == 0) continue;
+      }
+
+      output.push_back(folder[i]);
+    }
+
+    return output;
   }
 };

--- a/old-problems/1233/solution.cpp
+++ b/old-problems/1233/solution.cpp
@@ -1,0 +1,9 @@
+#include <string>
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<std::string> removeSubfolders(std::vector<std::string>& folder) {
+    return folder;
+  }
+};

--- a/old-problems/1233/test.yaml
+++ b/old-problems/1233/test.yaml
@@ -1,0 +1,26 @@
+name: 1233. Remove Sub-Folders from the Filesystem
+
+types:
+  inputs:
+    folder: std::vector<std::string>
+  output: std::vector<std::string>
+
+solutions:
+  cpp:
+    function: removeSubfolders
+
+test_cases:
+  example_1:
+    inputs:
+      folder: [/a, /a/b, /c/d, /c/d/e, /c/f]
+    output: [/a, /c/d, /c/f]
+
+  example_2:
+    inputs:
+      folder: [/a, /a/b/c, /a/b/d]
+    output: [/a]
+
+  case_1:
+    inputs:
+      folder: [/a/b/c, /a/b/ca, /a/b/d]
+    output: [/a/b/c, /a/b/ca, /a/b/d]


### PR DESCRIPTION
This pull request resolves #2102 by solving the problem [1233. Remove Sub-Folders from the Filesystem](https://leetcode.com/problems/remove-sub-folders-from-the-filesystem/) in C++. It does so by first sorting the given folders so that subfolders come after the parent folder. It then pushes each folder to the new list accordingly.