### PR TITLE
Solve Problem 1574. Shortest Subarray to be Removed to Make Array Sorted in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1561. Maximum Number of Coins You Can Get](https://leetcode.com/problems/maximum-number-of-coins-you-can-get/) | Medium | [C](./old-problems/1561/c/solution.c) [C++](./old-problems/1561/solution.cpp) |
 | [1563. Stone Game V](https://leetcode.com/problems/stone-game-v/) | Hard | [C](./old-problems/1563/c/solution.c) [C++](./old-problems/1563/solution.cpp) |
 | [1566. Detect Pattern of Length M Repeated K or More Times](https://leetcode.com/problems/detect-pattern-of-length-m-repeated-k-or-more-times/) | Easy | [C](./old-problems/1566/c/solution.c) [C++](./old-problems/1566/solution.cpp) |
-| [1574. Shortest Subarray to be Removed to Make Array Sorted](https://leetcode.com/problems/shortest-subarray-to-be-removed-to-make-array-sorted/) | Medium | [C++](./old-problems/1574/solution.cpp) |
+| [1574. Shortest Subarray to be Removed to Make Array Sorted](https://leetcode.com/problems/shortest-subarray-to-be-removed-to-make-array-sorted/) | Medium | [C](./old-problems/1574/c/solution.c) [C++](./old-problems/1574/solution.cpp) |
 | [1578. Minimum Time to Make Rope Colorful](https://leetcode.com/problems/minimum-time-to-make-rope-colorful/) | Medium | [C++](./old-problems/1578/solution.cpp) |
 | [1579. Remove Max Number of Edges to Keep Graph Fully Traversable](https://leetcode.com/problems/remove-max-number-of-edges-to-keep-graph-fully-traversable/) | Hard | [C](./old-problems/1579/c/solution.c) [C++](./old-problems/1579/solution.cpp) |
 | [1582. Special Positions in a Binary Matrix](https://leetcode.com/problems/special-positions-in-a-binary-matrix/) | Easy | [C](./old-problems/1582/c/solution.c) [C++](./old-problems/1582/solution.cpp) |

--- a/old-problems/1574/CMakeLists.txt
+++ b/old-problems/1574/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1574/c/interface.cpp
+++ b/old-problems/1574/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int findLengthOfShortestSubarray(int* arr, int arrSize);
+}
+
+int solution_c(std::vector<int> arr) {
+  return findLengthOfShortestSubarray(arr.data(), arr.size());
+}

--- a/old-problems/1574/c/solution.c
+++ b/old-problems/1574/c/solution.c
@@ -1,0 +1,3 @@
+int findLengthOfShortestSubarray(int* arr, int arrSize) {
+  return arr[arrSize - 1];
+}

--- a/old-problems/1574/c/solution.c
+++ b/old-problems/1574/c/solution.c
@@ -1,3 +1,23 @@
 int findLengthOfShortestSubarray(int* arr, int arrSize) {
-  return arr[arrSize - 1];
+  int left = 0;
+  while (left + 1 < arrSize && arr[left] <= arr[left + 1]) ++left;
+  if (left + 1 == arrSize) return 0;
+
+  int right = arrSize - 1;
+  while (arr[right - 1] <= arr[right]) --right;
+
+  int removed = arrSize - left - 1;
+  if (right < removed) removed = right;
+
+  int l = 0, r = right;
+  while (l <= left && r < arrSize) {
+    if (arr[l] <= arr[r]) {
+      if (r - l - 1 < removed) removed = r - l - 1;
+      ++l;
+    } else {
+      ++r;
+    }
+  }
+
+  return removed;
 }

--- a/old-problems/1574/test.yaml
+++ b/old-problems/1574/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: findLengthOfShortestSubarray
 


### PR DESCRIPTION
This pull request resolves #2179 by solving the problem [1574. Shortest Subarray to be Removed to Make Array Sorted](https://leetcode.com/problems/shortest-subarray-to-be-removed-to-make-array-sorted/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2166.