### PR TITLE
Solve Problem 769. Max Chunks To Make Sorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [739. Daily Temperatures](https://leetcode.com/problems/daily-temperatures/) | Medium | [C](./old-problems/0739/c/solution.c) [C++](./old-problems/0739/solution.cpp) |
 | [746. Min Cost Climbing Stairs](https://leetcode.com/problems/min-cost-climbing-stairs) | Easy | [C++](./problems/0746/solution.cpp) |
 | [752. Open the Lock](https://leetcode.com/problems/open-the-lock/) | Medium | [C](./old-problems/0752/c/solution.c) [C++](./old-problems/0752/solution.cpp) |
+| [769. Max Chunks To Make Sorted](https://leetcode.com/problems/max-chunks-to-make-sorted/) | Medium | [C++](./old-problems/0769/solution.cpp) |
 | [773. Sliding Puzzle](https://leetcode.com/problems/sliding-puzzle/) | Hard | [C++](./problems/0773/solution.cpp) |
 | [779. K-th Symbol in Grammar](https://leetcode.com/problems/k-th-symbol-in-grammar) | Medium | [C](./old-problems/0779/c/solution.c) [C++](./old-problems/0779/solution.cpp) |
 | [786. K-th Smallest Prime Fraction](https://leetcode.com/problems/k-th-smallest-prime-fraction/) | Medium | [C](./old-problems/0786/c/solution.c) [C++](./old-problems/0786/solution.cpp) |

--- a/old-problems/0769/CMakeLists.txt
+++ b/old-problems/0769/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/0769/solution.cpp
+++ b/old-problems/0769/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int maxChunksToSorted(std::vector<int>& arr) {
+    return arr.size();
+  }
+};

--- a/old-problems/0769/solution.cpp
+++ b/old-problems/0769/solution.cpp
@@ -3,6 +3,11 @@
 class Solution {
  public:
   int maxChunksToSorted(std::vector<int>& arr) {
-    return arr.size();
+    int chunks{0}, max{0};
+    for (int i{0}; i < static_cast<int>(arr.size()); ++i) {
+      if (arr[i] > max) max = arr[i];
+      if (max == i) ++chunks;
+    }
+    return chunks;
   }
 };

--- a/old-problems/0769/test.yaml
+++ b/old-problems/0769/test.yaml
@@ -1,0 +1,21 @@
+name: 769. Max Chunks To Make Sorted
+
+types:
+  inputs:
+    arr: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: maxChunksToSorted
+
+test_cases:
+  example_1:
+    inputs:
+      arr: [4, 3, 2, 1, 0]
+    output: 1
+
+  example_2:
+    inputs:
+      arr: [1, 0, 2, 3, 4]
+    output: 4


### PR DESCRIPTION
This pull request resolves #2287 by solving the problem [769. Max Chunks To Make Sorted](https://leetcode.com/problems/max-chunks-to-make-sorted/) in C++. It does so by keeping track of the maximum number while iterating through the array.