### PR TITLE
Fix CI Failing to Build Old Solutions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Setup Poetry
         uses: threeal/setup-poetry-action@v1.1.0
+        with:
+          version: 1.8.5
 
       - name: Cache Dependencies Build
         uses: threeal/cache-action@v0.2.1


### PR DESCRIPTION
This pull request resolves #2350 by updating the `test-old-solutions` step in the GitHub workflow to explicitly use Poetry version 1.8.5, ensuring compatibility and preventing build failures with old solutions.