### PR TITLE
Specify Runner OS Version in Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   test-solutions:
     name: Test Solutions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2
@@ -19,7 +19,7 @@ jobs:
 
   test-old-solutions:
     name: Test Old Solutions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This pull request resolves #2394 by manually specifying the runner OS version to be used in workflows, replacing the default latest version.