### PR TITLE
Optimize Solution for Problem 229. Majority Element II Without Hash Map

### DIFF
--- a/old-problems/0229/solution.cpp
+++ b/old-problems/0229/solution.cpp
@@ -5,18 +5,43 @@
 class Solution {
  public:
   std::vector<int> majorityElement(std::vector<int>& nums) {
-    std::unordered_map<int, int> counts;
-    for (auto num : nums) {
-      ++counts[num];
+    int majority1{0}, majority2{0}, count1{0}, count2{0};
+    for (const auto num : nums) {
+      if (num == majority1) {
+        ++count1;
+      } else if (num == majority2) {
+        ++count2;
+      } else if (count1 == 0) {
+        majority1 = num;
+        ++count1;
+      } else if (count2 == 0) {
+        majority2 = num;
+        ++count2;
+      } else {
+        --count1;
+        --count2;
+      }
     }
 
-    std::vector<int> result;
-    const int threshold = nums.size() / 3;
-    for (auto [num, count] : counts) {
-      if (count > threshold) result.push_back(num);
+    count1 = 0;
+    count2 = 0;
+    for (const auto num : nums) {
+      if (num == majority1) {
+        ++count1;
+      } else if (num == majority2) {
+        ++count2;
+      }
     }
 
-    std::sort(result.begin(), result.end());
-    return result;
+    const int limit = nums.size() / 3;
+    if (count1 > limit) {
+      return count2 > limit
+          ? std::vector<int>{majority1, majority2}
+          : std::vector<int>{majority1};
+    } else {
+      return count2 > limit
+          ? std::vector<int>{majority2}
+          : std::vector<int>{};
+    }
   }
 };


### PR DESCRIPTION
This pull request resolves #2396 by optimizing the C++ solution for [229. Majority Element II](https://leetcode.com/problems/majority-element-ii). It replaces the hash map approach with the [Boyer–Moore Majority Vote Algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore_majority_vote_algorithm), achieving linear time complexity and constant space usage.