### PR TITLE
Solve Problem 2657. Find the Prefix Common Array of Two Arrays in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2610. Convert an Array Into a 2D Array With Conditions](https://leetcode.com/problems/convert-an-array-into-a-2d-array-with-conditions) | Medium | [C++](./problems/2610/solution.cpp) |
 | [2641. Cousins in Binary Tree II](https://leetcode.com/problems/cousins-in-binary-tree-ii/) | Medium | [C++](./old-problems/2641/solution.cpp) |
 | [2642. Design Graph With Shortest Path Calculator](https://leetcode.com/problems/design-graph-with-shortest-path-calculator) | Hard | [C++](./old-problems/2642/solution.cpp) |
-| [2657. Find the Prefix Common Array of Two Arrays](https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/) | Medium | [C++](./old-problems/2657/solution.cpp) |
+| [2657. Find the Prefix Common Array of Two Arrays](https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/) | Medium | [C](./old-problems/2657/c/solution.c) [C++](./old-problems/2657/solution.cpp) |
 | [2678. Number of Senior Citizens](https://leetcode.com/problems/number-of-senior-citizens/) | Easy | [C](./old-problems/2678/c/solution.c) [C++](./old-problems/2678/solution.cpp) |
 | [2684. Maximum Number of Moves in a Grid](https://leetcode.com/problems/maximum-number-of-moves-in-a-grid/) | Medium | [C](./old-problems/2684/c/solution.c) [C++](./old-problems/2684/solution.cpp) |
 | [2696. Minimum String Length After Removing Substrings](https://leetcode.com/problems/minimum-string-length-after-removing-substrings/) | Easy | [C](./old-problems/2696/c/solution.c) [C++](./old-problems/2696/solution.cpp) |

--- a/old-problems/2657/CMakeLists.txt
+++ b/old-problems/2657/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2657/c/interface.cpp
+++ b/old-problems/2657/c/interface.cpp
@@ -1,0 +1,18 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+int* findThePrefixCommonArray(
+    int* A, int ASize, int* B, int BSize, int* returnSize);
+}
+
+std::vector<int> solution_c(std::vector<int> A, std::vector<int> B) {
+  int returnSize{};
+  int* returnData = findThePrefixCommonArray(
+      A.data(), A.size(), B.data(), B.size(), &returnSize);
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/2657/c/solution.c
+++ b/old-problems/2657/c/solution.c
@@ -1,5 +1,12 @@
 int* findThePrefixCommonArray(
     int* A, int ASize, int* B, int BSize, int* returnSize) {
-  *returnSize = ASize < BSize ? ASize : BSize;
-  return ASize < BSize ? A : B;
+  (void)BSize;
+  unsigned long long a = 0, b = 0;
+  for (int i = 0; i < ASize; ++i) {
+    a |= 1l << A[i];
+    b |= 1l << B[i];
+    A[i] = __builtin_popcountll(a & b);
+  }
+  *returnSize = ASize;
+  return A;
 }

--- a/old-problems/2657/c/solution.c
+++ b/old-problems/2657/c/solution.c
@@ -1,0 +1,5 @@
+int* findThePrefixCommonArray(
+    int* A, int ASize, int* B, int BSize, int* returnSize) {
+  *returnSize = ASize < BSize ? ASize : BSize;
+  return ASize < BSize ? A : B;
+}

--- a/old-problems/2657/test.yaml
+++ b/old-problems/2657/test.yaml
@@ -7,6 +7,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: findThePrefixCommonArray
 


### PR DESCRIPTION
This pull request resolves #2427 by solving the problem [2657. Find the Prefix Common Array of Two Arrays](https://leetcode.com/problems/find-the-prefix-common-array-of-two-arrays/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2367.