### PR TITLE
Solve Problem 2948. Make Lexicographically Smallest Array by Swapping Elements in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2914. Minimum Number of Changes to Make Binary String Beautiful](https://leetcode.com/problems/minimum-number-of-changes-to-make-binary-string-beautiful/) | Medium | [C](./old-problems/2914/c/solution.c) [C++](./old-problems/2914/solution.cpp) |
 | [2924. Find Champion II](https://leetcode.com/problems/find-champion-ii/description/) | Medium | [C++](./old-problems/2924/solution.cpp) |
 | [2938. Separate Black and White Balls](https://leetcode.com/problems/separate-black-and-white-balls/) | Medium | [C++](./old-problems/2938/solution.cpp) |
-| [2948. Make Lexicographically Smallest Array by Swapping Elements](https://leetcode.com/problems/make-lexicographically-smallest-array-by-swapping-elements/) | Medium | [C++](./old-problems/2948/solution.cpp) |
+| [2948. Make Lexicographically Smallest Array by Swapping Elements](https://leetcode.com/problems/make-lexicographically-smallest-array-by-swapping-elements/) | Medium | [C](./old-problems/2948/c/solution.c) [C++](./old-problems/2948/solution.cpp) |
 | [2958. Length of Longest Subarray With at Most K Frequency](https://leetcode.com/problems/length-of-longest-subarray-with-at-most-k-frequency/) | Medium | [C++](./problems/2958/solution.cpp) |
 | [2962. Count Subarrays Where Max Element Appears at Least K Times](https://leetcode.com/problems/count-subarrays-where-max-element-appears-at-least-k-times/) | Medium | [C](./old-problems/2962/c/solution.c) [C++](./old-problems/2962/solution.cpp) |
 | [2966. Divide Array Into Arrays With Max Difference](https://leetcode.com/problems/divide-array-into-arrays-with-max-difference/) | Medium | [C](./old-problems/2966/c/solution.c) [C++](./old-problems/2966/solution.cpp) |

--- a/old-problems/2948/CMakeLists.txt
+++ b/old-problems/2948/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2948/c/interface.cpp
+++ b/old-problems/2948/c/interface.cpp
@@ -1,0 +1,18 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+int* lexicographicallySmallestArray(
+    int* nums, int numsSize, int limit, int* returnSize);
+}
+
+std::vector<int> solution_c(std::vector<int> nums, int limit) {
+  int returnSize{};
+  int* returnData = lexicographicallySmallestArray(
+      nums.data(), nums.size(), limit, &returnSize);
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/2948/c/solution.c
+++ b/old-problems/2948/c/solution.c
@@ -1,0 +1,6 @@
+int* lexicographicallySmallestArray(
+    int* nums, int numsSize, int limit, int* returnSize) {
+  (void)limit;
+  *returnSize = numsSize;
+  return nums;
+}

--- a/old-problems/2948/c/solution.c
+++ b/old-problems/2948/c/solution.c
@@ -1,6 +1,40 @@
+#include <stdlib.h>
+#include <string.h>
+
+int* gNums;
+int compareIdxs(const void* a, const void* b) {
+  return gNums[*(int*)a] - gNums[*(int*)b];
+}
+
+int compare(const void* a, const void* b) {
+  return *(int*)a - *(int*)b;
+}
+
 int* lexicographicallySmallestArray(
     int* nums, int numsSize, int limit, int* returnSize) {
-  (void)limit;
+  int* numsIdxs = malloc(numsSize * sizeof(int));
+  for (int i = 0; i < numsSize; ++i) numsIdxs[i] = i;
+
+  gNums = nums;
+  qsort(numsIdxs, numsSize, sizeof(int), compareIdxs);
+
+  int* outputIdxs = malloc(numsSize * sizeof(int));
+  memcpy(outputIdxs, numsIdxs, numsSize * sizeof(int));
+
+  int prev = 0;
+  for (int i = 1; i < numsSize; ++i) {
+    if (nums[numsIdxs[i]] - nums[numsIdxs[i - 1]] > limit) {
+      qsort(outputIdxs + prev, i - prev, sizeof(int), compare);
+      prev = i;
+    }
+  }
+  qsort(outputIdxs + prev, numsSize - prev, sizeof(int), compare);
+
+  int* output = malloc(numsSize * sizeof(int));
+  for (int i = 0; i < numsSize; ++i) {
+    output[outputIdxs[i]] = nums[numsIdxs[i]];
+  }
+
   *returnSize = numsSize;
-  return nums;
+  return output;
 }

--- a/old-problems/2948/test.yaml
+++ b/old-problems/2948/test.yaml
@@ -7,6 +7,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: lexicographicallySmallestArray
 


### PR DESCRIPTION
This pull request resolves #2515 by solving the problem [2948. Make Lexicographically Smallest Array by Swapping Elements](https://leetcode.com/problems/make-lexicographically-smallest-array-by-swapping-elements/) in C++. It does so by implementing the same solution as the C++ solution to the problem implemented in #2474.