### PR TITLE
Solve Problem 1092. Shortest Common Supersequence in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1080. Insufficient Nodes in Root to Leaf Paths](https://leetcode.com/problems/insufficient-nodes-in-root-to-leaf-paths/) | Medium | [C++](./old-problems/1080/solution.cpp) |
 | [1081. Smallest Subsequence of Distinct Characters](https://leetcode.com/problems/smallest-subsequence-of-distinct-characters) | Medium | [C++](./problems/1081/solution.cpp) |
 | [1090. Largest Values From Labels](https://leetcode.com/problems/largest-values-from-labels/) | Medium | [C](./old-problems/1090/c/solution.c) [C++](./old-problems/1090/solution.cpp) |
-| [1092. Shortest Common Supersequence](https://leetcode.com/problems/shortest-common-supersequence/) | Hard | [C++](./old-problems/1092/solution.cpp) |
+| [1092. Shortest Common Supersequence](https://leetcode.com/problems/shortest-common-supersequence/) | Hard | [C](./old-problems/1092/c/solution.c) [C++](./old-problems/1092/solution.cpp) |
 | [1105. Filling Bookcase Shelves](https://leetcode.com/problems/filling-bookcase-shelves/) | Medium | [C](./old-problems/1105/c/solution.c) [C++](./old-problems/1105/solution.cpp) |
 | [1106. Parsing A Boolean Expression](https://leetcode.com/problems/parsing-a-boolean-expression/) | Hard | [C](./old-problems/1106/c/solution.c) [C++](./old-problems/1106/solution.cpp) |
 | [1109. Corporate Flight Bookings](https://leetcode.com/problems/corporate-flight-bookings/) | Medium | [C](./old-problems/1109/c/solution.c) [C++](./old-problems/1109/solution.cpp) |

--- a/old-problems/1092/CMakeLists.txt
+++ b/old-problems/1092/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1092/c/interface.cpp
+++ b/old-problems/1092/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+char* shortestCommonSupersequence(char* str1, char* str2);
+}
+
+std::string solution_c(std::string str1, std::string str2) {
+  return shortestCommonSupersequence(str1.data(), str2.data());
+}

--- a/old-problems/1092/c/solution.c
+++ b/old-problems/1092/c/solution.c
@@ -1,3 +1,54 @@
+#include <stdlib.h>
+#include <string.h>
+
 char* shortestCommonSupersequence(char* str1, char* str2) {
-  return *str1 > *str2 ? str1 : str2;
+  const int str1Len = strlen(str1);
+  const int str2Len = strlen(str2);
+
+  const int lcsSize = str1Len + 1;
+  int** lcs = malloc(lcsSize * sizeof(int*));
+
+  const int lcsColSize = str2Len + 1;
+  for (int i = 0; i < lcsSize; ++i) {
+    lcs[i] = malloc(lcsColSize * sizeof(int));
+    memset(lcs[i], 0, lcsColSize * sizeof(int));
+  }
+
+  for (int i = 1; i <= str1Len; ++i) {
+    for (int j = 1; j <= str2Len; ++j) {
+      if (str1[i - 1] == str2[j - 1]) {
+        lcs[i][j] = lcs[i - 1][j - 1] + 1;
+      } else {
+        lcs[i][j] = lcs[i - 1][j] >= lcs[i][j - 1]
+            ? lcs[i - 1][j]
+            : lcs[i][j - 1];
+      }
+    }
+  }
+
+  const int outputSize =
+      str1Len + str2Len - lcs[lcsSize - 1][lcsColSize - 1] + 1;
+
+  char* output = malloc(outputSize * sizeof(char));
+  output[outputSize - 1] = '\0';
+
+  int i = str1Len, j = str2Len, k = outputSize - 1;
+  while (i > 0 && j > 0) {
+    if (str1[i - 1] == str2[j - 1]) {
+      output[--k] = str1[--i];
+      --j;
+    } else if (lcs[i - 1][j] >= lcs[i][j - 1]) {
+      output[--k] = str1[--i];
+    } else {
+      output[--k] = str2[--j];
+    }
+  }
+
+  while (i > 0) output[--k] = str1[--i];
+  while (j > 0) output[--k] = str2[--j];
+
+  for (int i = 0; i < lcsSize; ++i) free(lcs[i]);
+  free(lcs);
+
+  return output;
 }

--- a/old-problems/1092/c/solution.c
+++ b/old-problems/1092/c/solution.c
@@ -1,0 +1,3 @@
+char* shortestCommonSupersequence(char* str1, char* str2) {
+  return *str1 > *str2 ? str1 : str2;
+}

--- a/old-problems/1092/test.yaml
+++ b/old-problems/1092/test.yaml
@@ -7,6 +7,7 @@ types:
   output: std::string
 
 solutions:
+  c:
   cpp:
     function: shortestCommonSupersequence
 


### PR DESCRIPTION
This pull request resolves #2797 by solving the problem [1092. Shortest Common Supersequence](https://leetcode.com/problems/shortest-common-supersequence/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2795.