### PR TITLE
Solve Problem 2379. Minimum Recolors to Get K Consecutive Black Blocks in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2370. Longest Ideal Subsequence](https://leetcode.com/problems/longest-ideal-subsequence/) | Medium | [C](./old-problems/2370/c/solution.c) [C++](./old-problems/2370/solution.cpp) |
 | [2373. Largest Local Values in a Matrix](https://leetcode.com/problems/largest-local-values-in-a-matrix/) | Easy | [C](./old-problems/2373/c/solution.c) [C++](./old-problems/2373/solution.cpp) |
 | [2375. Construct Smallest Number From DI String](https://leetcode.com/problems/construct-smallest-number-from-di-string/) | Medium | [C](./old-problems/2375/c/solution.c) [C++](./old-problems/2375/solution.cpp) |
-| [2379. Minimum Recolors to Get K Consecutive Black Blocks](https://leetcode.com/problems/minimum-recolors-to-get-k-consecutive-black-blocks/) | Easy | [C++](./old-problems/2379/solution.cpp) |
+| [2379. Minimum Recolors to Get K Consecutive Black Blocks](https://leetcode.com/problems/minimum-recolors-to-get-k-consecutive-black-blocks/) | Easy | [C](./old-problems/2379/c/solution.c) [C++](./old-problems/2379/solution.cpp) |
 | [2380. Time Needed to Rearrange a Binary String](https://leetcode.com/problems/time-needed-to-rearrange-a-binary-string/) | Medium | [C++](./old-problems/2380/solution.cpp) |
 | [2381. Shifting Letters II](https://leetcode.com/problems/shifting-letters-ii/description/) | Medium | [C](./old-problems/2381/c/solution.c) [C++](./old-problems/2381/solution.cpp) |
 | [2385. Amount of Time for Binary Tree to Be Infected](https://leetcode.com/problems/amount-of-time-for-binary-tree-to-be-infected/) | Medium | [C++](./old-problems/2385/solution.cpp) |

--- a/old-problems/2379/CMakeLists.txt
+++ b/old-problems/2379/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2379/c/interface.cpp
+++ b/old-problems/2379/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int minimumRecolors(char* blocks, int k);
+}
+
+int solution_c(std::string blocks, int k) {
+  return minimumRecolors(blocks.data(), k);
+}

--- a/old-problems/2379/c/solution.c
+++ b/old-problems/2379/c/solution.c
@@ -1,3 +1,19 @@
+#include <string.h>
+
 int minimumRecolors(char* blocks, int k) {
-  return blocks[0] + k;
+  const int blocksLen = strlen(blocks);
+
+  int freq = 0;
+  for (int i = 0; i < k; ++i) {
+    if (blocks[i] == 'W') ++freq;
+  }
+
+  int minFreq = freq;
+  for (int i = k; i < blocksLen; ++i) {
+    if (blocks[i] == 'W') ++freq;
+    if (blocks[i - k] == 'W') --freq;
+    if (freq < minFreq) minFreq = freq;
+  }
+
+  return minFreq;
 }

--- a/old-problems/2379/c/solution.c
+++ b/old-problems/2379/c/solution.c
@@ -1,0 +1,3 @@
+int minimumRecolors(char* blocks, int k) {
+  return blocks[0] + k;
+}

--- a/old-problems/2379/test.yaml
+++ b/old-problems/2379/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minimumRecolors
 


### PR DESCRIPTION
This pull request resolves #2859 by solving the problem [2379. Minimum Recolors to Get K Consecutive Black Blocks](https://leetcode.com/problems/minimum-recolors-to-get-k-consecutive-black-blocks/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2834.