### PR TITLE
Solve Problem 3191. Minimum Operations to Make Binary Array Elements Equal to One I

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,6 +725,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3160. Find the Number of Distinct Colors Among the Balls](https://leetcode.com/problems/find-the-number-of-distinct-colors-among-the-balls/) | Medium | [C++](./old-problems/3160/solution.cpp) |
 | [3174. Clear Digits](https://leetcode.com/problems/clear-digits/) | Easy | [C](./old-problems/3174/c/solution.c) [C++](./old-problems/3174/solution.cpp) |
 | [3163. String Compression III](https://leetcode.com/problems/string-compression-iii/description/) | Medium | [C](./old-problems/3163/c/solution.c) [C++](./old-problems/3163/solution.cpp) |
+| [3191. Minimum Operations to Make Binary Array Elements Equal to One I](https://leetcode.com/problems/minimum-operations-to-make-binary-array-elements-equal-to-one-i/) | Medium | [C++](./old-problems/3191/solution.cpp) |
 | [3217. Delete Nodes From Linked List Present in Array](https://leetcode.com/problems/delete-nodes-from-linked-list-present-in-array/) | Medium | [C++](./old-problems/3217/solution.cpp) |
 | [3223. Minimum Length of String After Operations](https://leetcode.com/problems/minimum-length-of-string-after-operations/) | Medium | [C](./old-problems/3223/c/solution.c) [C++](./old-problems/3223/solution.cpp) |
 | [3243. Shortest Distance After Road Addition Queries I](https://leetcode.com/problems/shortest-distance-after-road-addition-queries-i/) | Medium | [C++](./problems/3243/solution.cpp) |

--- a/old-problems/3191/CMakeLists.txt
+++ b/old-problems/3191/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3191/solution.cpp
+++ b/old-problems/3191/solution.cpp
@@ -3,6 +3,17 @@
 class Solution {
  public:
   int minOperations(std::vector<int>& nums) {
-    return nums.size();
+    int operations{0};
+    for (std::size_t i{2}; i < nums.size(); ++i) {
+      if (nums[i - 2] == 0) {
+        ++operations;
+        nums[i - 1] ^= 1;
+        nums[i] ^= 1;
+      }
+    }
+
+    return nums[nums.size() - 1] == 1 && nums[nums.size() - 2] == 1
+        ? operations
+        : -1;
   }
 };

--- a/old-problems/3191/solution.cpp
+++ b/old-problems/3191/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int minOperations(std::vector<int>& nums) {
+    return nums.size();
+  }
+};

--- a/old-problems/3191/test.yaml
+++ b/old-problems/3191/test.yaml
@@ -1,0 +1,21 @@
+name: 3191. Minimum Operations to Make Binary Array Elements Equal to One I
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: minOperations
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [0, 1, 1, 1, 0, 0]
+    output: 3
+
+  example_2:
+    inputs:
+      nums: [0, 1, 1, 1]
+    output: -1


### PR DESCRIPTION
This pull request resolves #2879 by solving the problem [3191. Minimum Operations to Make Binary Array Elements Equal to One I](https://leetcode.com/problems/minimum-operations-to-make-binary-array-elements-equal-to-one-i/) in C++. It does so by greedily performing the operation whenever it encounters a zero while iterating through the array.