### PR TITLE
Solve Problem 3191. Minimum Operations to Make Binary Array Elements Equal to One I in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,7 +727,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3160. Find the Number of Distinct Colors Among the Balls](https://leetcode.com/problems/find-the-number-of-distinct-colors-among-the-balls/) | Medium | [C++](./old-problems/3160/solution.cpp) |
 | [3174. Clear Digits](https://leetcode.com/problems/clear-digits/) | Easy | [C](./old-problems/3174/c/solution.c) [C++](./old-problems/3174/solution.cpp) |
 | [3163. String Compression III](https://leetcode.com/problems/string-compression-iii/description/) | Medium | [C](./old-problems/3163/c/solution.c) [C++](./old-problems/3163/solution.cpp) |
-| [3191. Minimum Operations to Make Binary Array Elements Equal to One I](https://leetcode.com/problems/minimum-operations-to-make-binary-array-elements-equal-to-one-i/) | Medium | [C++](./old-problems/3191/solution.cpp) |
+| [3191. Minimum Operations to Make Binary Array Elements Equal to One I](https://leetcode.com/problems/minimum-operations-to-make-binary-array-elements-equal-to-one-i/) | Medium | [C](./old-problems/3191/c/solution.c) [C++](./old-problems/3191/solution.cpp) |
 | [3217. Delete Nodes From Linked List Present in Array](https://leetcode.com/problems/delete-nodes-from-linked-list-present-in-array/) | Medium | [C++](./old-problems/3217/solution.cpp) |
 | [3223. Minimum Length of String After Operations](https://leetcode.com/problems/minimum-length-of-string-after-operations/) | Medium | [C](./old-problems/3223/c/solution.c) [C++](./old-problems/3223/solution.cpp) |
 | [3243. Shortest Distance After Road Addition Queries I](https://leetcode.com/problems/shortest-distance-after-road-addition-queries-i/) | Medium | [C++](./problems/3243/solution.cpp) |

--- a/old-problems/3191/CMakeLists.txt
+++ b/old-problems/3191/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3191/c/interface.cpp
+++ b/old-problems/3191/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minOperations(int* nums, int numsSize);
+}
+
+int solution_c(std::vector<int> nums) {
+  return minOperations(nums.data(), nums.size());
+}

--- a/old-problems/3191/c/solution.c
+++ b/old-problems/3191/c/solution.c
@@ -1,3 +1,14 @@
 int minOperations(int* nums, int numsSize) {
-  return nums[numsSize - 1];
+  int operations = 0;
+  for (int i = 2; i < numsSize; ++i) {
+    if (nums[i - 2] == 0) {
+      ++operations;
+      nums[i - 1] ^= 1;
+      nums[i] ^= 1;
+    }
+  }
+
+  return nums[numsSize - 1] == 1 && nums[numsSize - 2] == 1
+      ? operations
+      : -1;
 }

--- a/old-problems/3191/c/solution.c
+++ b/old-problems/3191/c/solution.c
@@ -1,0 +1,3 @@
+int minOperations(int* nums, int numsSize) {
+  return nums[numsSize - 1];
+}

--- a/old-problems/3191/test.yaml
+++ b/old-problems/3191/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minOperations
 


### PR DESCRIPTION
This pull request resolves #2891 by solving the problem [3191. Minimum Operations to Make Binary Array Elements Equal to One I](https://leetcode.com/problems/minimum-operations-to-make-binary-array-elements-equal-to-one-i/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2880.