### PR TITLE
Bump Catch2 to Version 3.8.0

### DIFF
--- a/package-lock
+++ b/package-lock
@@ -12,7 +12,7 @@ CPMDeclarePackage(Format.cmake
 )
 # Catch2
 CPMDeclarePackage(Catch2
-  VERSION 3.7.1
+  VERSION 3.8.0
   GITHUB_REPOSITORY catchorg/Catch2
   SYSTEM YES
   EXCLUDE_FROM_ALL YES


### PR DESCRIPTION
This pull request simply bumps Catch2 to version [3.8.0](https://github.com/catchorg/Catch2/releases/tag/v3.8.0).