### PR TITLE
Solve Problem 3375. Minimum Operations to Make Array Values Equal to K

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3264. Final Array State After K Multiplication Operations I](https://leetcode.com/problems/final-array-state-after-k-multiplication-operations-i/) | Easy | [C](./old-problems/3264/c/solution.c) [C++](./old-problems/3264/solution.cpp) |
 | [3270. Find the Key of the Numbers](https://leetcode.com/problems/find-the-key-of-the-numbers/) | Easy | [C](./old-problems/3270/c/solution.c) [C++](./old-problems/3270/solution.cpp) |
 | [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/) | Medium | [C](./old-problems/3356/c/solution.c) [C++](./old-problems/3356/solution.cpp) |
+| [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C++](./old-problems/3375/solution.cpp) |
 | [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C++](./old-problems/3396/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
 

--- a/old-problems/3375/CMakeLists.txt
+++ b/old-problems/3375/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3375/solution.cpp
+++ b/old-problems/3375/solution.cpp
@@ -3,6 +3,16 @@
 class Solution {
  public:
   int minOperations(std::vector<int>& nums, int k) {
-    return nums.size() * k;
+    std::vector<bool> exists(101, false);
+    int count{0};
+    for (const auto num : nums) {
+      if (num < k) return -1;
+      if (!exists[num]) {
+        exists[num] = true;
+        ++count;
+      }
+    }
+    if (exists[k]) --count;
+    return count;
   }
 };

--- a/old-problems/3375/solution.cpp
+++ b/old-problems/3375/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int minOperations(std::vector<int>& nums, int k) {
+    return nums.size() * k;
+  }
+};

--- a/old-problems/3375/test.yaml
+++ b/old-problems/3375/test.yaml
@@ -1,0 +1,30 @@
+name: 3375. Minimum Operations to Make Array Values Equal to K
+
+types:
+  inputs:
+    nums: std::vector<int>
+    k: int
+  output: int
+
+solutions:
+  cpp:
+    function: minOperations
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [5, 2, 5, 4, 5]
+      k: 2
+    output: 2
+
+  example_2:
+    inputs:
+      nums: [2, 1, 2]
+      k: 2
+    output: -1
+
+  example_3:
+    inputs:
+      nums: [9, 7, 5, 3]
+      k: 1
+    output: 4


### PR DESCRIPTION
This pull request resolves #2996 by solving the problem [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) in C++. It does so by simply counting the distinct numbers that are greater than `k`, or return `-1` if there is any number less than `k`.