### PR TITLE
Solve Problem 3396. Minimum Number of Operations to Make Elements in Array Distinct in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3270. Find the Key of the Numbers](https://leetcode.com/problems/find-the-key-of-the-numbers/) | Easy | [C](./old-problems/3270/c/solution.c) [C++](./old-problems/3270/solution.cpp) |
 | [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/) | Medium | [C](./old-problems/3356/c/solution.c) [C++](./old-problems/3356/solution.cpp) |
 | [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C++](./old-problems/3375/solution.cpp) |
-| [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C++](./old-problems/3396/solution.cpp) |
+| [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C](./old-problems/3396/c/solution.c) [C++](./old-problems/3396/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
 
 ## License

--- a/old-problems/3396/CMakeLists.txt
+++ b/old-problems/3396/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3396/c/interface.cpp
+++ b/old-problems/3396/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minimumOperations(int* nums, int numsSize);
+}
+
+int solution_c(std::vector<int> nums) {
+  return minimumOperations(nums.data(), nums.size());
+}

--- a/old-problems/3396/c/solution.c
+++ b/old-problems/3396/c/solution.c
@@ -1,3 +1,11 @@
 int minimumOperations(int* nums, int numsSize) {
-  return nums[numsSize - 1];
+  int indices[101] = {0};
+
+  int i = 0;
+  for (int j = 0; j < numsSize; ++j) {
+    if (indices[nums[j]] > i) i = indices[nums[j]];
+    indices[nums[j]] = j + 1;
+  }
+
+  return i % 3 == 0 ? i / 3 : i / 3 + 1;
 }

--- a/old-problems/3396/c/solution.c
+++ b/old-problems/3396/c/solution.c
@@ -1,0 +1,3 @@
+int minimumOperations(int* nums, int numsSize) {
+  return nums[numsSize - 1];
+}

--- a/old-problems/3396/test.yaml
+++ b/old-problems/3396/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minimumOperations
 


### PR DESCRIPTION
This pull request resolves #3030 by solving the problem [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2989.