### PR TITLE
Solve Problem 3375. Minimum Operations to Make Array Values Equal to K in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,7 +776,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3264. Final Array State After K Multiplication Operations I](https://leetcode.com/problems/final-array-state-after-k-multiplication-operations-i/) | Easy | [C](./old-problems/3264/c/solution.c) [C++](./old-problems/3264/solution.cpp) |
 | [3270. Find the Key of the Numbers](https://leetcode.com/problems/find-the-key-of-the-numbers/) | Easy | [C](./old-problems/3270/c/solution.c) [C++](./old-problems/3270/solution.cpp) |
 | [3356. Zero Array Transformation II](https://leetcode.com/problems/zero-array-transformation-ii/) | Medium | [C](./old-problems/3356/c/solution.c) [C++](./old-problems/3356/solution.cpp) |
-| [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C++](./old-problems/3375/solution.cpp) |
+| [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C](./old-problems/3375/c/solution.c) [C++](./old-problems/3375/solution.cpp) |
 | [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C](./old-problems/3396/c/solution.c) [C++](./old-problems/3396/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
 

--- a/old-problems/3375/CMakeLists.txt
+++ b/old-problems/3375/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3375/c/interface.cpp
+++ b/old-problems/3375/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minOperations(int* nums, int numsSize, int k);
+}
+
+int solution_c(std::vector<int> nums, int k) {
+  return minOperations(nums.data(), nums.size(), k);
+}

--- a/old-problems/3375/c/solution.c
+++ b/old-problems/3375/c/solution.c
@@ -1,0 +1,3 @@
+int minOperations(int* nums, int numsSize, int k) {
+  return nums[numsSize - 1] + k;
+}

--- a/old-problems/3375/c/solution.c
+++ b/old-problems/3375/c/solution.c
@@ -1,3 +1,15 @@
+#include <stdbool.h>
+
 int minOperations(int* nums, int numsSize, int k) {
-  return nums[numsSize - 1] + k;
+  bool exists[101] = {false};
+  int count = 0;
+  for (int i = 0; i < numsSize; ++i) {
+    if (nums[i] < k) return -1;
+    if (!exists[nums[i]]) {
+      exists[nums[i]] = true;
+      ++count;
+    }
+  }
+  if (exists[k]) --count;
+  return count;
 }

--- a/old-problems/3375/test.yaml
+++ b/old-problems/3375/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minOperations
 


### PR DESCRIPTION
This pull request resolves #3054 by solving the problem [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #2997.