### PR TITLE
Remove Unnecessary Copy Asignment in C++ Solution of Problem 47. Permutations II

### DIFF
--- a/old-problems/0047/solution.cpp
+++ b/old-problems/0047/solution.cpp
@@ -25,7 +25,6 @@ class Solution {
       for (int j{0}; j < 21; ++j) {
         if (freqs[j] != 0) {
           nums[i] = j - 10;
-          *it = nums;
           std::memcpy(it->data(), nums.data(), nums.size() * sizeof(int));
           ++it;
         }


### PR DESCRIPTION
This pull request resolves #3086 by simply removing an unnecessary copy asignment in C++ solution of problem [47. Permutations II](https://leetcode.com/problems/permutations-ii/).