### PR TITLE
Solve Problem 3467. Transform Array by Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -821,6 +821,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C](./old-problems/3375/c/solution.c) [C++](./old-problems/3375/solution.cpp) |
 | [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C](./old-problems/3396/c/solution.c) [C++](./old-problems/3396/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
+| [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) | Easy | [C++](./old-problems/3467/solution.cpp) |
 | [3516. Find Closest Person](https://leetcode.com/problems/find-closest-person/) | Easy | [C](./old-problems/3516/c/solution.c) [C++](./old-problems/3516/solution.cpp) |
 
 ## License

--- a/old-problems/3467/CMakeLists.txt
+++ b/old-problems/3467/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3467/solution.cpp
+++ b/old-problems/3467/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<int> transformArray(std::vector<int>& nums) {
+    return nums;
+  }
+};

--- a/old-problems/3467/solution.cpp
+++ b/old-problems/3467/solution.cpp
@@ -3,6 +3,11 @@
 class Solution {
  public:
   std::vector<int> transformArray(std::vector<int>& nums) {
+    std::size_t l{0};
+    for (std::size_t i{0}; i < nums.size(); ++i) {
+      if (nums[i] % 2 == 0) nums[l++] = 0;
+    }
+    while (l < nums.size()) nums[l++] = 1;
     return nums;
   }
 };

--- a/old-problems/3467/test.yaml
+++ b/old-problems/3467/test.yaml
@@ -1,0 +1,21 @@
+name: 3467. Transform Array by Parity
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: std::vector<int>
+
+solutions:
+  cpp:
+    function: transformArray
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [4, 3, 2, 1]
+    output: [0, 0, 1, 1]
+
+  example_2:
+    inputs:
+      nums: [1, 5, 1, 4, 2]
+    output: [0, 0, 1, 1, 1]


### PR DESCRIPTION
This pull request resolves #3217 by solving the problem [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) in C++. It does so by counting the even numbers in-place.