### PR TITLE
Solve Problem 3467. Transform Array by Parity in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,7 +827,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3375. Minimum Operations to Make Array Values Equal to K](https://leetcode.com/problems/minimum-operations-to-make-array-values-equal-to-k/) | Easy | [C](./old-problems/3375/c/solution.c) [C++](./old-problems/3375/solution.cpp) |
 | [3396. Minimum Number of Operations to Make Elements in Array Distinct](https://leetcode.com/problems/minimum-number-of-operations-to-make-elements-in-array-distinct/) | Easy | [C](./old-problems/3396/c/solution.c) [C++](./old-problems/3396/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
-| [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) | Easy | [C++](./old-problems/3467/solution.cpp) |
+| [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) | Easy | [C](./old-problems/3467/c/solution.c) [C++](./old-problems/3467/solution.cpp) |
 | [3516. Find Closest Person](https://leetcode.com/problems/find-closest-person/) | Easy | [C](./old-problems/3516/c/solution.c) [C++](./old-problems/3516/solution.cpp) |
 
 ## License

--- a/old-problems/3467/CMakeLists.txt
+++ b/old-problems/3467/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3467/c/interface.cpp
+++ b/old-problems/3467/c/interface.cpp
@@ -1,0 +1,16 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+int* transformArray(int* nums, int numsSize, int* returnSize);
+}
+
+std::vector<int> solution_c(std::vector<int> nums) {
+  int returnSize{};
+  int* returnData{transformArray(nums.data(), nums.size(), &returnSize)};
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/3467/c/solution.c
+++ b/old-problems/3467/c/solution.c
@@ -1,0 +1,4 @@
+int* transformArray(int* nums, int numsSize, int* returnSize) {
+  *returnSize = numsSize;
+  return nums;
+}

--- a/old-problems/3467/c/solution.c
+++ b/old-problems/3467/c/solution.c
@@ -1,4 +1,10 @@
 int* transformArray(int* nums, int numsSize, int* returnSize) {
+  int l = 0;
+  for (int i = 0; i < numsSize; ++i) {
+    if (nums[i] % 2 == 0) nums[l++] = 0;
+  }
+  while (l < numsSize) nums[l++] = 1;
+
   *returnSize = numsSize;
   return nums;
 }

--- a/old-problems/3467/test.yaml
+++ b/old-problems/3467/test.yaml
@@ -6,6 +6,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: transformArray
 


### PR DESCRIPTION
This pull request resolves #3259 by solving the problem [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3218.