### PR TITLE
Solve Problem 1689. Partitioning Into Minimum Number Of Deci-Binary Numbers in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1685. Sum of Absolute Differences in a Sorted Array](https://leetcode.com/problems/sum-of-absolute-differences-in-a-sorted-array/) | Medium | [C](./old-problems/1685/c/solution.c) [C++](./old-problems/1685/solution.cpp) |
 | [1686. Stone Game VI](https://leetcode.com/problems/stone-game-vi/) | Medium | [C](./old-problems/1686/c/solution.c) [C++](./old-problems/1686/solution.cpp) |
 | [1688. Count of Matches in Tournament](https://leetcode.com/problems/count-of-matches-in-tournament/description/) | Easy | [C](./old-problems/1688/c/solution.c) [C++](./old-problems/1688/solution.cpp) |
-| [1689. Partitioning Into Minimum Number Of Deci-Binary Numbers](https://leetcode.com/problems/partitioning-into-minimum-number-of-deci-binary-numbers/) | Medium | [C++](./old-problems/1689/solution.cpp) |
+| [1689. Partitioning Into Minimum Number Of Deci-Binary Numbers](https://leetcode.com/problems/partitioning-into-minimum-number-of-deci-binary-numbers/) | Medium | [C](./old-problems/1689/c/solution.c) [C++](./old-problems/1689/solution.cpp) |
 | [1690. Stone Game VII](https://leetcode.com/problems/stone-game-vii/) | Medium | [C](./old-problems/1690/c/solution.c) [C++](./old-problems/1690/solution.cpp) |
 | [1700. Number of Students Unable to Eat Lunch](https://leetcode.com/problems/number-of-students-unable-to-eat-lunch/) | Easy | [C](./old-problems/1700/c/solution.c) [C++](./old-problems/1700/solution.cpp) |
 | [1701. Average Waiting Time](https://leetcode.com/problems/average-waiting-time/) | Medium | [C](./old-problems/1701/c/solution.c) [C++](./old-problems/1701/solution.cpp) |

--- a/old-problems/1689/CMakeLists.txt
+++ b/old-problems/1689/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1689/c/interface.cpp
+++ b/old-problems/1689/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int minPartitions(char* n);
+}
+
+int solution_c(std::string n) {
+  return minPartitions(n.data());
+}

--- a/old-problems/1689/c/solution.c
+++ b/old-problems/1689/c/solution.c
@@ -1,0 +1,3 @@
+int minPartitions(char* n) {
+  return *n;
+}

--- a/old-problems/1689/c/solution.c
+++ b/old-problems/1689/c/solution.c
@@ -1,3 +1,7 @@
 int minPartitions(char* n) {
-  return *n;
+  char largest = '0';
+  for (char* c = n; *c != 0; ++c) {
+    if (*c > largest) largest = *c;
+  }
+  return largest - '0';
 }

--- a/old-problems/1689/test.yaml
+++ b/old-problems/1689/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minPartitions
 


### PR DESCRIPTION
This pull request resolves #3303 by solving the problem [1689. Partitioning Into Minimum Number Of Deci-Binary Numbers](https://leetcode.com/problems/partitioning-into-minimum-number-of-deci-binary-numbers/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3226.