### PR TITLE
Solve Problem 2859. Sum of Values at Indices With K Set Bits

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2843. Count Symmetric Integers](https://leetcode.com/problems/count-symmetric-integers/) | Easy | [C](./old-problems/2843/c/solution.c) [C++](./old-problems/2843/solution.cpp) |
 | [2845. Count of Interesting Subarrays](https://leetcode.com/problems/count-of-interesting-subarrays/) | Medium | [C++](./problems/2845/solution.cpp) |
 | [2849. Determine if a Cell Is Reachable at a Given Time](https://leetcode.com/problems/determine-if-a-cell-is-reachable-at-a-given-time) | Medium | [C](./old-problems/2849/c/solution.c) [C++](./old-problems/2849/solution.cpp) |
+| [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/) | Easy | [C++](./old-problems/2849/solution.cpp) |
 | [2864. Maximum Odd Binary Number](https://leetcode.com/problems/maximum-odd-binary-number/) | Easy | [C](./old-problems/2864/c/solution.c) [C++](./old-problems/2864/solution.cpp) |
 | [2870. Minimum Number of Operations to Make Array Empty](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-empty/) | Medium | [C++](./problems/2870/solution.cpp) |
 | [2872. Maximum Number of K-Divisible Components](https://leetcode.com/problems/maximum-number-of-k-divisible-components/) | Hard | [C](./old-problems/2872/c/solution.c) [C++](./old-problems/2872/solution.cpp) |

--- a/old-problems/2859/CMakeLists.txt
+++ b/old-problems/2859/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/2859/solution.cpp
+++ b/old-problems/2859/solution.cpp
@@ -1,8 +1,13 @@
+#include <bit>
 #include <vector>
 
 class Solution {
  public:
   int sumIndicesWithKSetBits(std::vector<int>& nums, int k) {
-    return nums.size() + k;
+    int sum{0};
+    for (std::size_t i{0}; i < nums.size(); ++i) {
+      if (std::popcount(i) == k) sum += nums[i];
+    }
+    return sum;
   }
 };

--- a/old-problems/2859/solution.cpp
+++ b/old-problems/2859/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int sumIndicesWithKSetBits(std::vector<int>& nums, int k) {
+    return nums.size() + k;
+  }
+};

--- a/old-problems/2859/test.yaml
+++ b/old-problems/2859/test.yaml
@@ -1,0 +1,24 @@
+name: 2859. Sum of Values at Indices With K Set Bits
+
+types:
+  inputs:
+    nums: std::vector<int>
+    k: int
+  output: int
+
+solutions:
+  cpp:
+    function: sumIndicesWithKSetBits
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [5, 10, 1, 5, 2]
+      k: 1
+    output: 13
+
+  example_2:
+    inputs:
+      nums: [4, 3, 2, 1]
+      k: 2
+    output: 1


### PR DESCRIPTION
This pull request resolves #3358 by solving the problem [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/) in C++ using the `std::popcount` function.