### PR TITLE
Solve Problem 1313. Decompress Run-Length Encoded List in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,7 +448,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1302. Deepest Leaves Sum](https://leetcode.com/problems/deepest-leaves-sum/) | Medium | [C++](./old-problems/1302/solution.cpp) |
 | [1309. Decrypt String from Alphabet to Integer Mapping](https://leetcode.com/problems/decrypt-string-from-alphabet-to-integer-mapping/) | Easy | [C](./old-problems/1309/c/solution.c) [C++](./old-problems/1309/solution.cpp) |
 | [1310. XOR Queries of a Subarray](https://leetcode.com/problems/xor-queries-of-a-subarray/) | Medium | [C++](./old-problems/1310/solution.cpp) |
-| [1313. Decompress Run-Length Encoded List](https://leetcode.com/problems/decompress-run-length-encoded-list/) | Easy | [C++](./old-problems/1313/solution.cpp) |
+| [1313. Decompress Run-Length Encoded List](https://leetcode.com/problems/decompress-run-length-encoded-list/) | Easy | [C](./old-problems/1313/c/solution.c) [C++](./old-problems/1313/solution.cpp) |
 | [1315. Sum of Nodes with Even-Valued Grandparent](https://leetcode.com/problems/sum-of-nodes-with-even-valued-grandparent/) | Medium | [C++](./old-problems/1315/solution.cpp) |
 | [1325. Delete Leaves With a Given Value](https://leetcode.com/problems/delete-leaves-with-a-given-value/) | Medium | [C++](./old-problems/1325/solution.cpp) |
 | [1329. Sort the Matrix Diagonally](https://leetcode.com/problems/sort-the-matrix-diagonally/) | Medium | [C](./old-problems/1329/c/solution.c) [C++](./old-problems/1329/solution.cpp) |

--- a/old-problems/1313/CMakeLists.txt
+++ b/old-problems/1313/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1313/c/interface.cpp
+++ b/old-problems/1313/c/interface.cpp
@@ -1,0 +1,16 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+int* decompressRLElist(int* nums, int numsSize, int* returnSize);
+}
+
+std::vector<int> solution_c(std::vector<int> nums) {
+  int returnSize{};
+  int* returnData{decompressRLElist(nums.data(), nums.size(), &returnSize)};
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/1313/c/solution.c
+++ b/old-problems/1313/c/solution.c
@@ -1,4 +1,20 @@
+#include <stdlib.h>
+
 int* decompressRLElist(int* nums, int numsSize, int* returnSize) {
-  *returnSize = numsSize;
-  return nums;
+  int outputSize = 0;
+  for (int i = 0; i < numsSize; i += 2) {
+    outputSize += nums[i];
+  }
+
+  int* output = malloc(outputSize * sizeof(int));
+  outputSize = 0;
+
+  for (int i = 1; i < numsSize; i += 2) {
+    for (int n = nums[i - 1]; n > 0; --n) {
+      output[outputSize++] = nums[i];
+    }
+  }
+
+  *returnSize = outputSize;
+  return output;
 }

--- a/old-problems/1313/c/solution.c
+++ b/old-problems/1313/c/solution.c
@@ -1,0 +1,4 @@
+int* decompressRLElist(int* nums, int numsSize, int* returnSize) {
+  *returnSize = numsSize;
+  return nums;
+}

--- a/old-problems/1313/test.yaml
+++ b/old-problems/1313/test.yaml
@@ -6,6 +6,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: decompressRLElist
 


### PR DESCRIPTION
This pull request resolves #3470 by solving the problem [1313. Decompress Run-Length Encoded List](https://leetcode.com/problems/decompress-run-length-encoded-list/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3331.