### PR TITLE
Solve Problem 2859. Sum of Values at Indices With K Set Bits in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2843. Count Symmetric Integers](https://leetcode.com/problems/count-symmetric-integers/) | Easy | [C](./old-problems/2843/c/solution.c) [C++](./old-problems/2843/solution.cpp) |
 | [2845. Count of Interesting Subarrays](https://leetcode.com/problems/count-of-interesting-subarrays/) | Medium | [C++](./problems/2845/solution.cpp) |
 | [2849. Determine if a Cell Is Reachable at a Given Time](https://leetcode.com/problems/determine-if-a-cell-is-reachable-at-a-given-time) | Medium | [C](./old-problems/2849/c/solution.c) [C++](./old-problems/2849/solution.cpp) |
-| [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/) | Easy | [C++](./old-problems/2849/solution.cpp) |
+| [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/) | Easy | [C](./old-problems/2859/c/solution.c) [C++](./old-problems/2849/solution.cpp) |
 | [2864. Maximum Odd Binary Number](https://leetcode.com/problems/maximum-odd-binary-number/) | Easy | [C](./old-problems/2864/c/solution.c) [C++](./old-problems/2864/solution.cpp) |
 | [2870. Minimum Number of Operations to Make Array Empty](https://leetcode.com/problems/minimum-number-of-operations-to-make-array-empty/) | Medium | [C++](./problems/2870/solution.cpp) |
 | [2872. Maximum Number of K-Divisible Components](https://leetcode.com/problems/maximum-number-of-k-divisible-components/) | Hard | [C](./old-problems/2872/c/solution.c) [C++](./old-problems/2872/solution.cpp) |

--- a/old-problems/2859/CMakeLists.txt
+++ b/old-problems/2859/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2859/c/interface.cpp
+++ b/old-problems/2859/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int sumIndicesWithKSetBits(int* nums, int numsSize, int k);
+}
+
+int solution_c(std::vector<int> nums, int k) {
+  return sumIndicesWithKSetBits(nums.data(), nums.size(), k);
+}

--- a/old-problems/2859/c/solution.c
+++ b/old-problems/2859/c/solution.c
@@ -1,0 +1,3 @@
+int sumIndicesWithKSetBits(int* nums, int numsSize, int k) {
+  return nums[numsSize - 1] + k;
+}

--- a/old-problems/2859/c/solution.c
+++ b/old-problems/2859/c/solution.c
@@ -1,3 +1,7 @@
 int sumIndicesWithKSetBits(int* nums, int numsSize, int k) {
-  return nums[numsSize - 1] + k;
+  int sum = 0;
+  for (int i = 0; i < numsSize; ++i) {
+    if (__builtin_popcount(i) == k) sum += nums[i];
+  }
+  return sum;
 }

--- a/old-problems/2859/test.yaml
+++ b/old-problems/2859/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: sumIndicesWithKSetBits
 


### PR DESCRIPTION
This pull request resolves #3488 by solving the problem [2859. Sum of Values at Indices With K Set Bits](https://leetcode.com/problems/sum-of-values-at-indices-with-k-set-bits/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3359.