### PR TITLE
Solve Problem 2900. Longest Unequal Adjacent Groups Subsequence I

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,6 +824,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2873. Maximum Value of an Ordered Triplet I](https://leetcode.com/problems/maximum-value-of-an-ordered-triplet-i/) | Easy | [C](./old-problems/2873/c/solution.c) [C++](./old-problems/2873/solution.cpp) |
 | [2874. Maximum Value of an Ordered Triplet II](https://leetcode.com/problems/maximum-value-of-an-ordered-triplet-ii/) | Medium | [C](./old-problems/2874/c/solution.c) [C++](./old-problems/2874/solution.cpp) |
 | [2894. Divisible and Non-divisible Sums Difference](https://leetcode.com/problems/divisible-and-non-divisible-sums-difference/) | Easy | [C](./old-problems/2894/c/solution.c) [C++](./old-problems/2894/solution.cpp) |
+| [2900. Longest Unequal Adjacent Groups Subsequence I](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-i/) | Easy | [C++](./old-problems/2900/solution.cpp) |
 | [2914. Minimum Number of Changes to Make Binary String Beautiful](https://leetcode.com/problems/minimum-number-of-changes-to-make-binary-string-beautiful/) | Medium | [C](./old-problems/2914/c/solution.c) [C++](./old-problems/2914/solution.cpp) |
 | [2923. Find Champion I](https://leetcode.com/problems/find-champion-i/) | Easy | [C](./old-problems/2923/c/solution.c) [C++](./old-problems/2923/solution.cpp) |
 | [2924. Find Champion II](https://leetcode.com/problems/find-champion-ii/description/) | Medium | [C++](./old-problems/2924/solution.cpp) |

--- a/old-problems/2900/CMakeLists.txt
+++ b/old-problems/2900/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/2900/solution.cpp
+++ b/old-problems/2900/solution.cpp
@@ -1,0 +1,11 @@
+#include <string>
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<std::string> getLongestSubsequence(
+      std::vector<std::string>& words, std::vector<int>& groups) {
+    words.resize(groups.size());
+    return words;
+  }
+};

--- a/old-problems/2900/solution.cpp
+++ b/old-problems/2900/solution.cpp
@@ -5,7 +5,15 @@ class Solution {
  public:
   std::vector<std::string> getLongestSubsequence(
       std::vector<std::string>& words, std::vector<int>& groups) {
-    words.resize(groups.size());
+    std::size_t n{1};
+    int group{groups[0]};
+    for (std::size_t i{1}; i < words.size(); ++i) {
+      if (groups[i] != group) {
+        group = groups[i];
+        words[n++] = words[i];
+      }
+    }
+    words.resize(n);
     return words;
   }
 };

--- a/old-problems/2900/test.yaml
+++ b/old-problems/2900/test.yaml
@@ -1,0 +1,24 @@
+name: 2900. Longest Unequal Adjacent Groups Subsequence I
+
+types:
+  inputs:
+    words: std::vector<std::string>
+    groups: std::vector<int>
+  output: std::vector<std::string>
+
+solutions:
+  cpp:
+    function: getLongestSubsequence
+
+test_cases:
+  example_1:
+    inputs:
+      words: [e, a, b]
+      groups: [0, 0, 1]
+    output: [e, b]
+
+  example_2:
+    inputs:
+      words: [a, b, c, d]
+      groups: [1, 0, 1, 1]
+    output: [a, b, c]


### PR DESCRIPTION
This pull request resolves #3514 by solving the problem [2900. Longest Unequal Adjacent Groups Subsequence I](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-i/) in C++. It does so by selecting word alternately between each group.