### PR TITLE
Solve Problem 1323. Maximum 69 Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1310. XOR Queries of a Subarray](https://leetcode.com/problems/xor-queries-of-a-subarray/) | Medium | [C++](./old-problems/1310/solution.cpp) |
 | [1313. Decompress Run-Length Encoded List](https://leetcode.com/problems/decompress-run-length-encoded-list/) | Easy | [C++](./old-problems/1313/solution.cpp) |
 | [1315. Sum of Nodes with Even-Valued Grandparent](https://leetcode.com/problems/sum-of-nodes-with-even-valued-grandparent/) | Medium | [C++](./old-problems/1315/solution.cpp) |
+| [1323. Maximum 69 Number](https://leetcode.com/problems/maximum-69-number/) | Easy | [C++](./old-problems/1323/solution.cpp) |
 | [1325. Delete Leaves With a Given Value](https://leetcode.com/problems/delete-leaves-with-a-given-value/) | Medium | [C++](./old-problems/1325/solution.cpp) |
 | [1329. Sort the Matrix Diagonally](https://leetcode.com/problems/sort-the-matrix-diagonally/) | Medium | [C](./old-problems/1329/c/solution.c) [C++](./old-problems/1329/solution.cpp) |
 | [1331. Rank Transform of an Array](https://leetcode.com/problems/rank-transform-of-an-array/) | Easy | [C](./old-problems/1331/c/solution.c) [C++](./old-problems/1331/solution.cpp) |

--- a/old-problems/1323/CMakeLists.txt
+++ b/old-problems/1323/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1323/solution.cpp
+++ b/old-problems/1323/solution.cpp
@@ -1,6 +1,10 @@
 class Solution {
  public:
   int maximum69Number(int num) {
+    if (num >= 1000 && num / 1000 == 6) return num + 3000;
+    if (num >= 100 && num / 100 % 10 == 6) return num + 300;
+    if (num >= 10 && num / 10 % 10 == 6) return num + 30;
+    if (num % 10 == 6) return num + 3;
     return num;
   }
 };

--- a/old-problems/1323/solution.cpp
+++ b/old-problems/1323/solution.cpp
@@ -1,0 +1,6 @@
+class Solution {
+ public:
+  int maximum69Number(int num) {
+    return num;
+  }
+};

--- a/old-problems/1323/test.yaml
+++ b/old-problems/1323/test.yaml
@@ -1,0 +1,26 @@
+name: 1323. Maximum 69 Number
+
+types:
+  inputs:
+    num: int
+  output: int
+
+solutions:
+  cpp:
+    function: maximum69Number
+
+test_cases:
+  example_1:
+    inputs:
+      num: 9669
+    output: 9969
+
+  example_2:
+    inputs:
+      num: 9996
+    output: 9999
+
+  example_3:
+    inputs:
+      num: 9999
+    output: 9999


### PR DESCRIPTION
This pull request resolves #3524 by solving the problem [1323. Maximum 69 Number](https://leetcode.com/problems/maximum-69-number/) in C++. It does so by flipping the leftmost `6` to `9` if there's any.