### PR TITLE
Reintroduce Threeal's Cache Action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,11 @@ jobs:
           version: 1.8.5
 
       - name: Cache Dependencies Build
-        uses: actions/cache@v4.2.3
+        uses: threeal/cache-action@v1.0.0
         with:
-          key: CPM-${{ runner.os }}-${{ hashFiles('package-lock') }}
-          path: build/_deps
+          key: CPM-${{ runner.os }}
+          version: ${{ hashFiles('package-lock') }}
+          files: build/_deps
 
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@v6


### PR DESCRIPTION
This pull request resolves #3772 by reintroducing back [Threeal's cache action](https://github.com/marketplace/actions/cache-action) for caching builds in this project..