### PR TITLE
Solve Problem 1557. Minimum Number of Vertices to Reach All Nodes in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1550. Three Consecutive Odds](https://leetcode.com/problems/three-consecutive-odds/) | Easy | [C](./old-problems/1550/c/solution.c) [C++](./old-problems/1550/solution.cpp) |
 | [1551. Minimum Operations to Make Array Equal](https://leetcode.com/problems/minimum-operations-to-make-array-equal/) | Medium | [C](./old-problems/1551/c/solution.c) [C++](./old-problems/1551/solution.cpp) |
 | [1552. Magnetic Force Between Two Balls](https://leetcode.com/problems/magnetic-force-between-two-balls/) | Medium | [C](./old-problems/1552/c/solution.c) [C++](./old-problems/1552/solution.cpp) |
-| [1557. Minimum Number of Vertices to Reach All Nodes](https://leetcode.com/problems/minimum-number-of-vertices-to-reach-all-nodes/) | Medium | [C++](./old-problems/1557/solution.cpp) |
+| [1557. Minimum Number of Vertices to Reach All Nodes](https://leetcode.com/problems/minimum-number-of-vertices-to-reach-all-nodes/) | Medium | [C](./old-problems/1557/c/solution.c) [C++](./old-problems/1557/solution.cpp) |
 | [1561. Maximum Number of Coins You Can Get](https://leetcode.com/problems/maximum-number-of-coins-you-can-get/) | Medium | [C](./old-problems/1561/c/solution.c) [C++](./old-problems/1561/solution.cpp) |
 | [1563. Stone Game V](https://leetcode.com/problems/stone-game-v/) | Hard | [C](./old-problems/1563/c/solution.c) [C++](./old-problems/1563/solution.cpp) |
 | [1566. Detect Pattern of Length M Repeated K or More Times](https://leetcode.com/problems/detect-pattern-of-length-m-repeated-k-or-more-times/) | Easy | [C](./old-problems/1566/c/solution.c) [C++](./old-problems/1566/solution.cpp) |

--- a/old-problems/1557/CMakeLists.txt
+++ b/old-problems/1557/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1557/c/interface.cpp
+++ b/old-problems/1557/c/interface.cpp
@@ -1,0 +1,26 @@
+#include <cstring>
+#include <vector>
+
+extern "C" {
+int* findSmallestSetOfVertices(
+    int n, int** edges, int edgesSize, int* edgesColSize, int* returnSize);
+}
+
+std::vector<int> solution_c(int n, std::vector<std::vector<int>> edges) {
+  std::vector<int*> edgesDatas(edges.size());
+  std::vector<int> edgesSizes(edges.size());
+  for (std::size_t i{0}; i < edges.size(); ++i) {
+    edgesDatas[i] = edges[i].data();
+    edgesSizes[i] = edges[i].size();
+  }
+
+  int returnSize{};
+  int* returnData{
+      findSmallestSetOfVertices(
+          n, edgesDatas.data(), edges.size(), edgesSizes.data(), &returnSize)};
+
+  std::vector<int> output(returnSize);
+  std::memcpy(output.data(), returnData, returnSize * sizeof(int));
+
+  return output;
+}

--- a/old-problems/1557/c/solution.c
+++ b/old-problems/1557/c/solution.c
@@ -1,0 +1,6 @@
+int* findSmallestSetOfVertices(
+    int n, int** edges, int edgesSize, int* edgesColSize, int* returnSize) {
+  (void)n;
+  *returnSize = edgesColSize[edgesSize - 1];
+  return edges[edgesSize - 1];
+}

--- a/old-problems/1557/c/solution.c
+++ b/old-problems/1557/c/solution.c
@@ -1,6 +1,24 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
 int* findSmallestSetOfVertices(
     int n, int** edges, int edgesSize, int* edgesColSize, int* returnSize) {
-  (void)n;
-  *returnSize = edgesColSize[edgesSize - 1];
-  return edges[edgesSize - 1];
+  (void)edgesColSize;
+
+  bool* exists = malloc(n * sizeof(bool));
+  memset(exists, false, n * sizeof(bool));
+  for (int i = 0; i < edgesSize; ++i) {
+    exists[edges[i][1]] = true;
+  }
+
+  int* output = malloc(n * sizeof(int));
+  int outputSize = 0;
+
+  for (int i = 0; i < n; ++i) {
+    if (!exists[i]) output[outputSize++] = i;
+  }
+
+  *returnSize = outputSize;
+  return output;
 }

--- a/old-problems/1557/test.yaml
+++ b/old-problems/1557/test.yaml
@@ -7,6 +7,7 @@ types:
   output: std::vector<int>
 
 solutions:
+  c:
   cpp:
     function: findSmallestSetOfVertices
 


### PR DESCRIPTION
This pull request resolves #3778 by solving the problem [1557. Minimum Number of Vertices to Reach All Nodes](https://leetcode.com/problems/minimum-number-of-vertices-to-reach-all-nodes/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3563.