### PR TITLE
Solve Problem 2901. Longest Unequal Adjacent Groups Subsequence II in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,7 +868,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2874. Maximum Value of an Ordered Triplet II](https://leetcode.com/problems/maximum-value-of-an-ordered-triplet-ii/) | Medium | [C](./old-problems/2874/c/solution.c) [C++](./old-problems/2874/solution.cpp) |
 | [2894. Divisible and Non-divisible Sums Difference](https://leetcode.com/problems/divisible-and-non-divisible-sums-difference/) | Easy | [C](./old-problems/2894/c/solution.c) [C++](./old-problems/2894/solution.cpp) |
 | [2900. Longest Unequal Adjacent Groups Subsequence I](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-i/) | Easy | [C](./old-problems/2900/c/solution.c) [C++](./old-problems/2900/solution.cpp) |
-| [2901. Longest Unequal Adjacent Groups Subsequence II](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-ii/) | Medium | [C++](./old-problems/2901/solution.cpp) |
+| [2901. Longest Unequal Adjacent Groups Subsequence II](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-ii/) | Medium | [C](./old-problems/2901/c/solution.c) [C++](./old-problems/2901/solution.cpp) |
 | [2914. Minimum Number of Changes to Make Binary String Beautiful](https://leetcode.com/problems/minimum-number-of-changes-to-make-binary-string-beautiful/) | Medium | [C](./old-problems/2914/c/solution.c) [C++](./old-problems/2914/solution.cpp) |
 | [2918. Minimum Equal Sum of Two Arrays After Replacing Zeros](https://leetcode.com/problems/minimum-equal-sum-of-two-arrays-after-replacing-zeros/) | Medium | [C++](./old-problems/2918/solution.cpp) |
 | [2923. Find Champion I](https://leetcode.com/problems/find-champion-i/) | Easy | [C](./old-problems/2923/c/solution.c) [C++](./old-problems/2923/solution.cpp) |

--- a/old-problems/2901/CMakeLists.txt
+++ b/old-problems/2901/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2901/c/interface.cpp
+++ b/old-problems/2901/c/interface.cpp
@@ -1,0 +1,28 @@
+#include <string>
+#include <vector>
+
+extern "C" {
+char** getWordsInLongestSubsequence(
+    char** words, int wordsSize, int* groups, int groupsSize, int* returnSize);
+}
+
+std::vector<std::string> solution_c(
+    std::vector<std::string> words, std::vector<int> groups) {
+  std::vector<char*> wordsDatas(words.size());
+  for (std::size_t i{0}; i < words.size(); ++i) {
+    wordsDatas[i] = words[i].data();
+  }
+
+  int returnSize{};
+  char** returnData{
+      getWordsInLongestSubsequence(
+          wordsDatas.data(), words.size(), groups.data(), groups.size(),
+          &returnSize)};
+
+  std::vector<std::string> output(returnSize);
+  for (int i{0}; i < returnSize; ++i) {
+    output[i] = returnData[i];
+  }
+
+  return output;
+}

--- a/old-problems/2901/c/solution.c
+++ b/old-problems/2901/c/solution.c
@@ -1,0 +1,7 @@
+char** getWordsInLongestSubsequence(
+    char** words, int wordsSize, int* groups, int groupsSize, int* returnSize) {
+  (void)groups;
+  (void)groupsSize;
+  *returnSize = wordsSize;
+  return words;
+}

--- a/old-problems/2901/c/solution.c
+++ b/old-problems/2901/c/solution.c
@@ -1,7 +1,63 @@
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+static bool validHammingDistance(char* a, int aSize, char* b);
+
 char** getWordsInLongestSubsequence(
     char** words, int wordsSize, int* groups, int groupsSize, int* returnSize) {
-  (void)groups;
   (void)groupsSize;
-  *returnSize = wordsSize;
-  return words;
+
+  int* wordLens = malloc(wordsSize * sizeof(int));
+  for (int i = 0; i < wordsSize; ++i) {
+    wordLens[i] = strlen(words[i]);
+  }
+
+  int* lengths = malloc(wordsSize * sizeof(int));
+  int* prevs = malloc(wordsSize * sizeof(int));
+
+  int maxI = 0;
+  lengths[0] = 1;
+
+  for (int i = 1; i < wordsSize; ++i) {
+    lengths[i] = 1;
+    for (int j = i; j > 0; --j) {
+      if (lengths[j - 1] + 1 >= lengths[i] &&
+          groups[j - 1] != groups[i] &&
+          wordLens[j - 1] == wordLens[i] &&
+          validHammingDistance(words[j - 1], wordLens[j - 1], words[i])) {
+        lengths[i] = lengths[j - 1] + 1;
+        prevs[i] = j - 1;
+
+        if (lengths[i] > lengths[maxI]) maxI = i;
+      }
+    }
+  }
+
+  const int outputSize = lengths[maxI];
+  char** output = malloc(outputSize * sizeof(char*));
+  for (int i = outputSize - 1; i >= 0; --i) {
+    output[i] = words[maxI];
+    maxI = prevs[maxI];
+  }
+
+  *returnSize = outputSize;
+
+  free(wordLens);
+  free(lengths);
+  free(prevs);
+
+  return output;
+}
+
+static bool validHammingDistance(char* a, int aSize, char* b) {
+  for (int i = 0; i < aSize; ++i) {
+    if (a[i] != b[i]) {
+      while (++i < aSize) {
+        if (a[i] != b[i]) return false;
+      }
+      return true;
+    }
+  }
+  return false;
 }

--- a/old-problems/2901/test.yaml
+++ b/old-problems/2901/test.yaml
@@ -7,6 +7,7 @@ types:
   output: std::vector<std::string>
 
 solutions:
+  c:
   cpp:
     function: getWordsInLongestSubsequence
 


### PR DESCRIPTION
This pull request resolves #3800 by solving the problem [2901. Longest Unequal Adjacent Groups Subsequence II](https://leetcode.com/problems/longest-unequal-adjacent-groups-subsequence-ii/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3535.