### PR TITLE
Remove Setup Ninja Action in CI Workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,6 @@ jobs:
           version: ${{ hashFiles('package-lock') }}
           files: build/_deps
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v6
-
       - name: Build Solutions
         uses: threeal/cmake-action@v2.1.0
         with:


### PR DESCRIPTION
This pull request resolves #3821 by removing the `seanmiddleditch/gha-setup-ninja` action from the CI workflow.