### PR TITLE
Bump CPM.cmake to Version 0.42.0

### DIFF
--- a/cmake/CPM.cmake
+++ b/cmake/CPM.cmake
@@ -2,8 +2,8 @@
 #
 # SPDX-FileCopyrightText: Copyright (c) 2019-2023 Lars Melchior and contributors
 
-set(CPM_DOWNLOAD_VERSION 0.40.8)
-set(CPM_HASH_SUM f2c95720301a3fb2ee34488f0ab5c87f)
+set(CPM_DOWNLOAD_VERSION 0.42.0)
+set(CPM_HASH_SUM e5facfa5d8d61f058d5a6e3e5391a3b7)
 
 if(CPM_SOURCE_CACHE)
   set(CPM_DOWNLOAD_LOCATION "${CPM_SOURCE_CACHE}/cpm/CPM_${CPM_DOWNLOAD_VERSION}.cmake")


### PR DESCRIPTION
This pull request simply bumps the CPM.cmake to version [0.42.0](https://github.com/cpm-cmake/CPM.cmake/releases/tag/v0.42.0).