### PR TITLE
Solve Problem 3480. Maximize Subarrays After Removing One Conflicting Pair

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3427. Sum of Variable Length Subarrays](https://leetcode.com/problems/sum-of-variable-length-subarrays/) | Easy | [C](./old-problems/3427/c/solution.c) [C++](./old-problems/3427/solution.cpp) |
 | [3443. Maximum Manhattan Distance After K Changes](https://leetcode.com/problems/maximum-manhattan-distance-after-k-changes/) | Medium | [C](./old-problems/3443/c/solution.c) [C++](./old-problems/3443/solution.cpp) |
 | [3467. Transform Array by Parity](https://leetcode.com/problems/transform-array-by-parity/) | Easy | [C](./old-problems/3467/c/solution.c) [C++](./old-problems/3467/solution.cpp) |
+| [3480. Maximize Subarrays After Removing One Conflicting Pair](https://leetcode.com/problems/maximize-subarrays-after-removing-one-conflicting-pair/) | Hard | [C++](./old-problems/3480/solution.cpp) |
 | [3498. Reverse Degree of a String](https://leetcode.com/problems/reverse-degree-of-a-string/) | Easy | [C](./old-problems/3498/c/solution.c) [C++](./old-problems/3498/solution.cpp) |
 | [3502. Minimum Cost to Reach Every Position](https://leetcode.com/problems/minimum-cost-to-reach-every-position/) | Easy | [C](./old-problems/3502/c/solution.c) [C++](./old-problems/3502/solution.cpp) |
 | [3512. Minimum Operations to Make Array Sum Divisible by K](https://leetcode.com/problems/minimum-operations-to-make-array-sum-divisible-by-k/) | Easy | [C](./old-problems/3512/c/solution.c) [C++](./old-problems/3512/solution.cpp) |

--- a/old-problems/3480/CMakeLists.txt
+++ b/old-problems/3480/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3480/solution.cpp
+++ b/old-problems/3480/solution.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+class Solution {
+ public:
+  long long maxSubarrays(
+      int n, std::vector<std::vector<int>>& conflictingPairs) {
+    return n + conflictingPairs.size();
+  }
+};

--- a/old-problems/3480/test.yaml
+++ b/old-problems/3480/test.yaml
@@ -1,0 +1,24 @@
+name: 3480. Maximize Subarrays After Removing One Conflicting Pair
+
+types:
+  inputs:
+    n: int
+    conflictingPairs: std::vector<std::vector<int>>
+  output: long long
+
+solutions:
+  cpp:
+    function: maxSubarrays
+
+test_cases:
+  example_1:
+    inputs:
+      n: 4
+      conflictingPairs: [[2, 3], [1, 4]]
+    output: 9
+
+  example_2:
+    inputs:
+      n: 5
+      conflictingPairs: [[1, 2], [2, 5], [3, 5]]
+    output: 12


### PR DESCRIPTION
This pull request resolves #3901 by solving the problem [3480. Maximize Subarrays After Removing One Conflicting Pair](https://leetcode.com/problems/maximize-subarrays-after-removing-one-conflicting-pair/) in C++.