### PR TITLE
Improve Solution to Problem 2419. Longest Subarray With Maximum Bitwise AND

### DIFF
--- a/old-problems/2419/c/solution.c
+++ b/old-problems/2419/c/solution.c
@@ -1,19 +1,17 @@
 int longestSubarray(int* nums, int numsSize) {
-  int maxConsecutive = 0;
-  int maxNum = 0;
+  int consecutive = 0, maxConsecutive = 0, maxNum = 0;
   for (int i = 0; i < numsSize; ++i) {
-    if (nums[i] < maxNum) continue;
-    if (nums[i] > maxNum) {
-      maxNum = nums[i];
+    if (nums[i] < maxNum) {
+      consecutive = 0;
+    } else if (nums[i] > maxNum) {
+      consecutive = 1;
       maxConsecutive = 1;
-      for (++i; i < numsSize && nums[i] == maxNum; ++i) ++maxConsecutive;
-      --i;
-    } else {
       maxNum = nums[i];
-      int consecutive = 1;
-      for (++i; i < numsSize && nums[i] == maxNum; ++i) ++consecutive;
-      if (consecutive > maxConsecutive) maxConsecutive = consecutive;
-      --i;
+    } else {
+      ++consecutive;
+      if (consecutive > maxConsecutive) {
+        maxConsecutive = consecutive;
+      }
     }
   }
   return maxConsecutive;

--- a/old-problems/2419/solution.cpp
+++ b/old-problems/2419/solution.cpp
@@ -3,21 +3,19 @@
 class Solution {
  public:
   int longestSubarray(std::vector<int>& nums) {
-    int maxConsecutive{0};
-    int maxNum{0};
-    for (std::size_t i{0}; i < nums.size(); ++i) {
-      if (nums[i] < maxNum) continue;
-      if (nums[i] > maxNum) {
-        maxNum = nums[i];
+    int consecutive{0}, maxConsecutive{0}, maxNum{0};
+    for (const int num : nums) {
+      if (num < maxNum) {
+        consecutive = 0;
+      } else if (num > maxNum) {
+        consecutive = 1;
         maxConsecutive = 1;
-        for (++i; i < nums.size() && nums[i] == maxNum; ++i) ++maxConsecutive;
-        --i;
+        maxNum = num;
       } else {
-        maxNum = nums[i];
-        int consecutive{1};
-        for (++i; i < nums.size() && nums[i] == maxNum; ++i) ++consecutive;
-        if (consecutive > maxConsecutive) maxConsecutive = consecutive;
-        --i;
+        ++consecutive;
+        if (consecutive > maxConsecutive) {
+          maxConsecutive = consecutive;
+        }
       }
     }
     return maxConsecutive;


### PR DESCRIPTION
This pull request resolves #3914 by improving the solution to the problem [2419. Longest Subarray With Maximum Bitwise AND](https://leetcode.com/problems/longest-subarray-with-maximum-bitwise-and/) by finding the longest consecutive sequence of the maximum number in the given array.