### PR TITLE
Solve Problem 2710. Remove Trailing Zeros From a String in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2698. Find the Punishment Number of an Integer](https://leetcode.com/problems/find-the-punishment-number-of-an-integer/) | Medium | [C](./old-problems/2698/c/solution.c) [C++](./old-problems/2698/solution.cpp) |
 | [2706. Buy Two Chocolates](https://leetcode.com/problems/buy-two-chocolates/) | Easy | [C](./old-problems/2706/c/solution.c) [C++](./old-problems/2706/solution.cpp) |
 | [2707. Extra Characters in a String](https://leetcode.com/problems/extra-characters-in-a-string/) | Medium | [C](./old-problems/2707/c/solution.c) [C++](./old-problems/2707/solution.cpp) |
-| [2710. Remove Trailing Zeros From a String](https://leetcode.com/problems/remove-trailing-zeros-from-a-string/) | Easy | [C++](./old-problems/2710/solution.cpp) |
+| [2710. Remove Trailing Zeros From a String](https://leetcode.com/problems/remove-trailing-zeros-from-a-string/) | Easy | [C](./old-problems/2710/c/solution.c) [C++](./old-problems/2710/solution.cpp) |
 | [2742. Painting the Walls](https://leetcode.com/problems/painting-the-walls) | Hard | [C++](./problems/2742/solution.cpp) |
 | [2744. Find Maximum Number of String Pairs](https://leetcode.com/problems/find-maximum-number-of-string-pairs/) | Easy | [C](./old-problems/2744/c/solution.c) [C++](./old-problems/2744/solution.cpp) |
 | [2747. Count Zero Request Servers](https://leetcode.com/problems/count-zero-request-servers/) | Medium | [C](./old-problems/2747/c/solution.c) [C++](./old-problems/2747/solution.cpp) |

--- a/old-problems/2710/CMakeLists.txt
+++ b/old-problems/2710/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2710/c/interface.cpp
+++ b/old-problems/2710/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+char* removeTrailingZeros(char* num);
+}
+
+std::string solution_c(std::string num) {
+  return removeTrailingZeros(num.data());
+}

--- a/old-problems/2710/c/solution.c
+++ b/old-problems/2710/c/solution.c
@@ -1,0 +1,3 @@
+char* removeTrailingZeros(char* num) {
+  return num;
+}

--- a/old-problems/2710/c/solution.c
+++ b/old-problems/2710/c/solution.c
@@ -1,3 +1,8 @@
+#include <string.h>
+
 char* removeTrailingZeros(char* num) {
+  int n = strlen(num) - 1;
+  while (n >= 0 && num[n] == '0') --n;
+  num[n + 1] = 0;
   return num;
 }

--- a/old-problems/2710/test.yaml
+++ b/old-problems/2710/test.yaml
@@ -6,6 +6,7 @@ types:
   output: std::string
 
 solutions:
+  c:
   cpp:
     function: removeTrailingZeros
 


### PR DESCRIPTION
This pull request resolves #3950 by solving the problem [2710. Remove Trailing Zeros From a String](https://leetcode.com/problems/remove-trailing-zeros-from-a-string/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3700.