### PR TITLE
Solve Problem 2311. Longest Binary Subsequence Less Than or Equal to K in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -757,7 +757,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2290. Minimum Obstacle Removal to Reach Corner](https://leetcode.com/problems/minimum-obstacle-removal-to-reach-corner/) | Hard | [C++](./problems/2290/solution.cpp) |
 | [2294. Partition Array Such That Maximum Difference Is K](https://leetcode.com/problems/partition-array-such-that-maximum-difference-is-k/) | Medium | [C++](./old-problems/2294/solution.cpp) |
 | [2302. Count Subarrays With Score Less Than K](https://leetcode.com/problems/count-subarrays-with-score-less-than-k/) | Hard | [C](./old-problems/2302/c/solution.c) [C++](./old-problems/2302/solution.cpp) |
-| [2311. Longest Binary Subsequence Less Than or Equal to K](https://leetcode.com/problems/longest-binary-subsequence-less-than-or-equal-to-k/) | Medium | [C++](./old-problems/2311/solution.cpp) |
+| [2311. Longest Binary Subsequence Less Than or Equal to K](https://leetcode.com/problems/longest-binary-subsequence-less-than-or-equal-to-k/) | Medium | [C](./old-problems/2311/c/solution.c) [C++](./old-problems/2311/solution.cpp) |
 | [2315. Count Asterisks](https://leetcode.com/problems/count-asterisks/) | Easy | [C](./old-problems/2315/c/solution.c) [C++](./old-problems/2315/solution.cpp) |
 | [2317. Maximum XOR After Operations](https://leetcode.com/problems/maximum-xor-after-operations/) | Medium | [C](./old-problems/2317/c/solution.c) [C++](./old-problems/2317/solution.cpp) |
 | [2325. Decode the Message](https://leetcode.com/problems/decode-the-message/) | Easy | [C](./old-problems/2325/c/solution.c) [C++](./old-problems/2325/solution.cpp) |

--- a/old-problems/2311/CMakeLists.txt
+++ b/old-problems/2311/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/2311/c/interface.cpp
+++ b/old-problems/2311/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int longestSubsequence(char* s, int k);
+}
+
+int solution_c(std::string s, int k) {
+  return longestSubsequence(s.data(), k);
+}

--- a/old-problems/2311/c/solution.c
+++ b/old-problems/2311/c/solution.c
@@ -1,0 +1,3 @@
+int longestSubsequence(char* s, int k) {
+  return *s + k;
+}

--- a/old-problems/2311/c/solution.c
+++ b/old-problems/2311/c/solution.c
@@ -1,3 +1,15 @@
 int longestSubsequence(char* s, int k) {
-  return *s + k;
+  unsigned long long num = 0;
+  int count = 0, maxCount = 0;
+  while (*s != 0) {
+    ++count;
+    num = num << 1 | (*s == '0' ? 0 : 1);
+    while (num > (unsigned long long)k) {
+      num &= ~(1 << (63 - __builtin_clzll(num)));
+      --count;
+    }
+    if (count > maxCount) maxCount = count;
+    ++s;
+  }
+  return maxCount;
 }

--- a/old-problems/2311/test.yaml
+++ b/old-problems/2311/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: longestSubsequence
 


### PR DESCRIPTION
This pull request resolves #4008 by solving the problem [2311. Longest Binary Subsequence Less Than or Equal to K](https://leetcode.com/problems/longest-binary-subsequence-less-than-or-equal-to-k/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #3799.