### PR TITLE
Solve Problem 2273. Find Resultant Array After Removing Anagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2264. Largest 3-Same-Digit Number in String](https://leetcode.com/problems/largest-3-same-digit-number-in-string/) | Easy | [C](./old-problems/2264/c/solution.c) [C++](./old-problems/2264/solution.cpp) |
 | [2226. Maximum Candies Allocated to K Children](https://leetcode.com/problems/maximum-candies-allocated-to-k-children/) | Medium | [C](./old-problems/2226/c/solution.c) [C++](./old-problems/2226/solution.cpp) |
 | [2270. Number of Ways to Split Array](https://leetcode.com/problems/number-of-ways-to-split-array/) | Medium | [C](./old-problems/2270/c/solution.c) [C++](./old-problems/2270/solution.cpp) |
+| [2273. Find Resultant Array After Removing Anagrams](https://leetcode.com/problems/find-resultant-array-after-removing-anagrams/) | Easy | [C++](./old-problems/2273/solution.cpp) |
 | [2275. Largest Combination With Bitwise AND Greater Than Zero](https://leetcode.com/problems/largest-combination-with-bitwise-and-greater-than-zero/) | Medium | [C](./old-problems/2275/c/solution.c) [C++](./old-problems/2275/solution.cpp) |
 | [2278. Percentage of Letter in String](https://leetcode.com/problems/percentage-of-letter-in-string/) | Easy | [C](./old-problems/2278/c/solution.c) [C++](./old-problems/2278/solution.cpp) |
 | [2285. Maximum Total Importance of Roads](https://leetcode.com/problems/maximum-total-importance-of-roads/) | Medium | [C](./old-problems/2285/c/solution.c) [C++](./old-problems/2285/solution.cpp) |

--- a/old-problems/2273/CMakeLists.txt
+++ b/old-problems/2273/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/2273/solution.cpp
+++ b/old-problems/2273/solution.cpp
@@ -1,0 +1,9 @@
+#include <string>
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<std::string> removeAnagrams(std::vector<std::string>& words) {
+    return words;
+  }
+};

--- a/old-problems/2273/test.yaml
+++ b/old-problems/2273/test.yaml
@@ -1,0 +1,21 @@
+name: 2273. Find Resultant Array After Removing Anagrams
+
+types:
+  inputs:
+    nums: std::vector<std::string>
+  output: std::vector<std::string>
+
+solutions:
+  cpp:
+    function: removeAnagrams
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [abba, baba, bbaa, cd, cd]
+    output: [abba, cd]
+
+  example_2:
+    inputs:
+      nums: [a, b, c, d, e]
+    output: [a, b, c, d, e]


### PR DESCRIPTION
This pull request resolves #4219 by solving the problem [2273. Find Resultant Array After Removing Anagrams](https://leetcode.com/problems/find-resultant-array-after-removing-anagrams/) in C++.