### PR TITLE
Solve Problem 3658. GCD of Odd and Even Sums in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1057,7 +1057,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3541. Find Most Frequent Vowel and Consonant](https://leetcode.com/problems/find-most-frequent-vowel-and-consonant/) | Easy | [C](./old-problems/3541/c/solution.c) [C++](./old-problems/3541/solution.cpp) |
 | [3550. Smallest Index With Digit Sum Equal to Index](https://leetcode.com/problems/smallest-index-with-digit-sum-equal-to-index/) | Easy | [C](./old-problems/3550/c/solution.c) [C++](./old-problems/3550/solution.cpp) |
 | [3602. Hexadecimal and Hexatrigesimal Conversion](https://leetcode.com/problems/hexadecimal-and-hexatrigesimal-conversion/) | Easy | [C](./old-problems/3602/c/solution.c) [C++](./old-problems/3602/solution.cpp) |
-| [3658. GCD of Odd and Even Sums](https://leetcode.com/problems/gcd-of-odd-and-even-sums/) | Easy | [C++](./old-problems/3658/solution.cpp) |
+| [3658. GCD of Odd and Even Sums](https://leetcode.com/problems/gcd-of-odd-and-even-sums/) | Easy | [C](./old-problems/3658/c/solution.c) [C++](./old-problems/3658/solution.cpp) |
 | [3668. Restore Finishing Order](https://leetcode.com/problems/restore-finishing-order/) | Easy | [C](./old-problems/3668/c/solution.c) [C++](./old-problems/3668/solution.cpp) |
 | [3683. Earliest Time to Finish One Task](https://leetcode.com/problems/earliest-time-to-finish-one-task/) | Easy | [C++](./old-problems/3683/solution.cpp) |
 

--- a/old-problems/3658/CMakeLists.txt
+++ b/old-problems/3658/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3658/c/interface.cpp
+++ b/old-problems/3658/c/interface.cpp
@@ -1,0 +1,7 @@
+extern "C" {
+int gcdOfOddEvenSums(int n);
+}
+
+int solution_c(int n) {
+  return gcdOfOddEvenSums(n);
+}

--- a/old-problems/3658/c/solution.c
+++ b/old-problems/3658/c/solution.c
@@ -1,0 +1,3 @@
+int gcdOfOddEvenSums(int n) {
+  return n;
+}

--- a/old-problems/3658/test.yaml
+++ b/old-problems/3658/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: gcdOfOddEvenSums
 


### PR DESCRIPTION
This pull request resolves #4238 by solving the problem [3658. GCD of Odd and Even Sums](https://leetcode.com/problems/gcd-of-odd-and-even-sums/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #4092.