### PR TITLE
Solve Problem 1850. Minimum Adjacent Swaps to Reach the Kth Smallest Number

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1844. Replace All Digits with Characters](https://leetcode.com/problems/replace-all-digits-with-characters/) | Easy | [C](./old-problems/1844/c/solution.c) [C++](./old-problems/1844/solution.cpp) |
 | [1845. Seat Reservation Manager](https://leetcode.com/problems/seat-reservation-manager/) | Medium | [C++](./old-problems/1845/solution.cpp) |
 | [1846. Maximum Element After Decreasing and Rearranging](https://leetcode.com/problems/maximum-element-after-decreasing-and-rearranging) | Medium | [C](./old-problems/1846/c/solution.c) [C++](./old-problems/1846/solution.cpp) |
+| [1850. Minimum Adjacent Swaps to Reach the Kth Smallest Number](https://leetcode.com/problems/minimum-adjacent-swaps-to-reach-the-kth-smallest-number/) | Medium | [C++](./old-problems/1850/solution.cpp) |
 | [1859. Sorting the Sentence](https://leetcode.com/problems/sorting-the-sentence/) | Easy | [C](./old-problems/1859/c/solution.c) [C++](./old-problems/1859/solution.cpp) |
 | [1860. Incremental Memory Leak](https://leetcode.com/problems/incremental-memory-leak/) | Medium | [C++](./old-problems/1860/solution.cpp) |
 | [1861. Rotating the Box](https://leetcode.com/problems/rotating-the-box/) | Medium | [C](./old-problems/1861/c/solution.c) [C++](./old-problems/1861/solution.cpp) |

--- a/old-problems/1850/CMakeLists.txt
+++ b/old-problems/1850/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1850/solution.cpp
+++ b/old-problems/1850/solution.cpp
@@ -1,8 +1,25 @@
+#include <algorithm>
 #include <string>
 
 class Solution {
  public:
   int getMinSwaps(std::string num, int k) {
-    return num.size() + k;
+    std::string original{num};
+    while (--k >= 0) {
+      std::next_permutation(num.begin(), num.end());
+    }
+
+    int swaps{0};
+    for (std::size_t i{0}; i < num.size(); ++i) {
+      std::size_t j{i};
+      while (original[j] != num[i]) ++j;
+      swaps += j - i;
+      while (j > i) {
+        original[j] = original[j - 1];
+        --j;
+      }
+    }
+
+    return swaps;
   }
 };

--- a/old-problems/1850/solution.cpp
+++ b/old-problems/1850/solution.cpp
@@ -1,0 +1,8 @@
+#include <string>
+
+class Solution {
+ public:
+  int getMinSwaps(std::string num, int k) {
+    return num.size() + k;
+  }
+};

--- a/old-problems/1850/test.yaml
+++ b/old-problems/1850/test.yaml
@@ -1,0 +1,30 @@
+name: 1850. Minimum Adjacent Swaps to Reach the Kth Smallest Number
+
+types:
+  inputs:
+    num: std::string
+    k: int
+  output: int
+
+solutions:
+  cpp:
+    function: getMinSwaps
+
+test_cases:
+  example_1:
+    inputs:
+      num: "5489355142"
+      k: 4
+    output: 2
+
+  example_2:
+    inputs:
+      num: "11112"
+      k: 4
+    output: 4
+
+  example_3:
+    inputs:
+      num: "00123"
+      k: 1
+    output: 1


### PR DESCRIPTION
This pull request resolves #4719 by solving the problem [1850. Minimum Adjacent Swaps to Reach the Kth Smallest Number](https://leetcode.com/problems/minimum-adjacent-swaps-to-reach-the-kth-smallest-number/) in C++. It does so by getting the next `kth` permutation using `std::next_permutation`, and then compare the swap needed from the original to the permutation.