### PR TITLE
Bump Copyright Year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023-2025 Alfi Maulana
+Copyright (c) 2023-2026 Alfi Maulana
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1243,4 +1243,4 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 
 This project is licensed under the terms of the [MIT License](./LICENSE).
 
-Copyright © 2023-2025 [Alfi Maulana](https://github.com/threeal)
+Copyright © 2023-2026 [Alfi Maulana](https://github.com/threeal)


### PR DESCRIPTION
This pull request bumps the copyright year in the `LICENSE` file and the license section of `README.md` file to 2026.