### PR TITLE
Improve Solution to Problem 66. Plus One Without Using Reverse

### DIFF
--- a/problems/0066/solution.cpp
+++ b/problems/0066/solution.cpp
@@ -4,19 +4,24 @@
 class Solution {
  public:
   std::vector<int> plusOne(std::vector<int>& digits) {
-    std::reverse(digits.begin(), digits.end());
-    std::size_t i = 0;
+    std::size_t i{digits.size() - 1};
     ++digits[i];
-    while (digits[i] >= 10) {
-      ++i;
-      if (i == digits.size()) {
-        digits.push_back(digits[i - 1] / 10);
-      } else {
-        digits[i] += digits[i - 1] / 10;
-      }
-      digits[i - 1] %= 10;
+
+    while (i > 0 && digits[i] >= 10) {
+      ++digits[i - 1];
+      digits[i] %= 10;
+      --i;
     }
-    std::reverse(digits.begin(), digits.end());
+
+    if (digits[i] >= 10) {
+      digits.resize(digits.size() + 1);
+      for (std::size_t j{digits.size() - 1}; j > 0; --j) {
+        digits[j] = digits[j - 1];
+      }
+      digits[0] = 1;
+      digits[1] %= 10;
+    }
+
     return digits;
   }
 };

--- a/problems/0066/test.yaml
+++ b/problems/0066/test.yaml
@@ -22,3 +22,8 @@ cases:
     inputs:
       digits: [9]
     output: [1, 0]
+
+  - name: test case 6
+    inputs:
+      digits: [9, 9]
+    output: [1, 0, 0]


### PR DESCRIPTION
This pull request resolves #4925 by improving the C++ solution to the problem [66. Plus One](https://leetcode.com/problems/plus-one/) to be implemented without using `std::reverse`.