### PR TITLE
Solve Problem 3510. Minimum Pair Removal to Sort Array II

### DIFF
--- a/README.md
+++ b/README.md
@@ -1251,6 +1251,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3498. Reverse Degree of a String](https://leetcode.com/problems/reverse-degree-of-a-string/) | Easy | [C](./old-problems/3498/c/solution.c) [C++](./old-problems/3498/solution.cpp) |
 | [3502. Minimum Cost to Reach Every Position](https://leetcode.com/problems/minimum-cost-to-reach-every-position/) | Easy | [C](./old-problems/3502/c/solution.c) [C++](./old-problems/3502/solution.cpp) |
 | [3508. Implement Router](https://leetcode.com/problems/implement-router/) | Medium | [C++](./old-problems/3508/solution.cpp) |
+| [3510. Minimum Pair Removal to Sort Array II](https://leetcode.com/problems/minimum-pair-removal-to-sort-array-ii/) | Hard | [C++](./old-problems/3510/solution.cpp) |
 | [3512. Minimum Operations to Make Array Sum Divisible by K](https://leetcode.com/problems/minimum-operations-to-make-array-sum-divisible-by-k/) | Easy | [C](./old-problems/3512/c/solution.c) [C++](./old-problems/3512/solution.cpp) |
 | [3516. Find Closest Person](https://leetcode.com/problems/find-closest-person/) | Easy | [C](./old-problems/3516/c/solution.c) [C++](./old-problems/3516/solution.cpp) |
 | [3527. Find the Most Common Response](https://leetcode.com/problems/find-the-most-common-response/) | Medium | [C++](./old-problems/3527/solution.cpp) |

--- a/old-problems/3510/CMakeLists.txt
+++ b/old-problems/3510/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3510/solution.cpp
+++ b/old-problems/3510/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int minimumPairRemoval(std::vector<int>& nums) {
+    return nums.size();
+  }
+};

--- a/old-problems/3510/solution.cpp
+++ b/old-problems/3510/solution.cpp
@@ -1,8 +1,106 @@
+#include <queue>
+#include <tuple>
 #include <vector>
 
 class Solution {
  public:
   int minimumPairRemoval(std::vector<int>& nums) {
-    return nums.size();
+    int invertedCount{0};
+    std::vector<bool> isInverted(nums.size() - 1, false);
+    for (std::size_t i{1}; i < nums.size(); ++i) {
+      if (nums[i] < nums[i - 1]) {
+        isInverted[i - 1] = true;
+        ++invertedCount;
+      }
+    }
+
+    if (invertedCount == 0) return 0;
+
+    std::vector<long long> llnums(nums.size());
+    for (std::size_t i{0}; i < nums.size(); ++i) llnums[i] = nums[i];
+
+    std::vector<bool> isRemoved(llnums.size(), false);
+    std::vector<std::size_t> lefts(llnums.size()), rights(llnums.size());
+
+    std::priority_queue<
+        std::tuple<long long, std::size_t, std::size_t>,
+        std::vector<std::tuple<long long, std::size_t, std::size_t>>,
+        std::greater<>>
+        minPairs{};
+
+    lefts[0] = llnums.size();
+    rights[0] = 1;
+
+    for (std::size_t i{1}; i < llnums.size(); ++i) {
+      lefts[i] = i - 1;
+      rights[i] = i + 1;
+      minPairs.push({llnums[i - 1] + llnums[i], i - 1, i});
+    }
+
+    int removal{0};
+    while (invertedCount > 0) {
+      ++removal;
+
+      while (true) {
+        const auto [sum, i, j] = minPairs.top();
+        if (isRemoved[i] || isRemoved[j] || llnums[i] + llnums[j] != sum) {
+          minPairs.pop();
+        } else {
+          break;
+        }
+      }
+
+      const auto [sum, i, j] = minPairs.top();
+
+      llnums[i] += llnums[j];
+      isRemoved[j] = true;
+
+      if (isInverted[i]) {
+        isInverted[i] = false;
+        --invertedCount;
+      }
+
+      if (isInverted[j]) {
+        --invertedCount;
+      }
+
+      const std::size_t l{findNext(lefts, isRemoved, i)};
+      if (l < llnums.size()) {
+        rights[l] = i;
+        minPairs.push({llnums[l] + llnums[i], l, i});
+        if (llnums[i] >= llnums[l]) {
+          if (isInverted[l]) {
+            isInverted[l] = false;
+            --invertedCount;
+          }
+        } else {
+          if (!isInverted[l]) {
+            isInverted[l] = true;
+            ++invertedCount;
+          }
+        }
+      }
+
+      std::size_t r{findNext(rights, isRemoved, j)};
+      if (r < llnums.size()) {
+        lefts[r] = i;
+        minPairs.push({llnums[i] + llnums[r], i, r});
+        if (llnums[r] < llnums[i]) {
+          isInverted[i] = true;
+          ++invertedCount;
+        }
+      }
+    }
+
+    return removal;
+  }
+
+ private:
+  static std::size_t findNext(
+      std::vector<std::size_t>& nexts, const std::vector<bool>& isRemoved,
+      std::size_t i) {
+    return nexts[i] < isRemoved.size() && isRemoved[nexts[i]]
+        ? (nexts[i] = findNext(nexts, isRemoved, nexts[i]))
+        : nexts[i];
   }
 };

--- a/old-problems/3510/test.yaml
+++ b/old-problems/3510/test.yaml
@@ -24,3 +24,8 @@ test_cases:
     inputs:
       nums: [2, 2, -1, 3, -2, 2, 1, 1, 1, 0, -1]
     output: 9
+
+  test_case_443:
+    inputs:
+      nums: [-1, 2, 2, -2, -3, 0, 2, 1, 0, 0, 1]
+    output: 9

--- a/old-problems/3510/test.yaml
+++ b/old-problems/3510/test.yaml
@@ -19,3 +19,8 @@ test_cases:
     inputs:
       nums: [1, 2, 2]
     output: 0
+
+  test_case_4:
+    inputs:
+      nums: [2, 2, -1, 3, -2, 2, 1, 1, 1, 0, -1]
+    output: 9

--- a/old-problems/3510/test.yaml
+++ b/old-problems/3510/test.yaml
@@ -1,0 +1,21 @@
+name: 3510. Minimum Pair Removal to Sort Array II
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: minimumPairRemoval
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [5, 2, 3, 1]
+    output: 2
+
+  example_2:
+    inputs:
+      nums: [1, 2, 2]
+    output: 0


### PR DESCRIPTION
This pull request resolves #5149 by solving the problem [3510. Minimum Pair Removal to Sort Array II](https://leetcode.com/problems/minimum-pair-removal-to-sort-array-ii/) in C++ using a heap queue.