### PR TITLE
Solve Problem 3818. Minimum Prefix Removal to Make Array Strictly Increasing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1371,6 +1371,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3798. Largest Even Number](https://leetcode.com/problems/largest-even-number/) | Easy | [C](./old-problems/3798/c/solution.c) [C++](./old-problems/3798/solution.cpp) |
 | [3803. Count Residue Prefixes](https://leetcode.com/problems/count-residue-prefixes/) | Easy | [C++](./old-problems/3803/solution.cpp) |
 | [3804. Number of Centered Subarrays](https://leetcode.com/problems/number-of-centered-subarrays/) | Medium | [C](./old-problems/3804/c/solution.c) [C++](./old-problems/3804/solution.cpp) |
+| [3818. Minimum Prefix Removal to Make Array Strictly Increasing](https://leetcode.com/problems/minimum-prefix-removal-to-make-array-strictly-increasing/) | Medium | [C++](./old-problems/3818/solution.cpp) |
 | [3823. Reverse Letters Then Special Characters in a String](https://leetcode.com/problems/reverse-letters-then-special-characters-in-a-string/) | Easy | [C](./old-problems/3823/c/solution.c) [C++](./old-problems/3823/solution.cpp) |
 | [3857. Minimum Cost to Split into Ones](https://leetcode.com/problems/minimum-cost-to-split-into-ones/) | Medium | [C](./old-problems/3857/c/solution.c) [C++](./old-problems/3857/solution.cpp) |
 | [3861. Minimum Capacity Box](https://leetcode.com/problems/minimum-capacity-box/) | Easy | [C](./old-problems/3861/c/solution.c) [C++](./old-problems/3861/solution.cpp) |

--- a/old-problems/3818/CMakeLists.txt
+++ b/old-problems/3818/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3818/solution.cpp
+++ b/old-problems/3818/solution.cpp
@@ -3,6 +3,8 @@
 class Solution {
  public:
   int minimumPrefixLength(std::vector<int>& nums) {
-    return nums.size();
+    std::size_t i{nums.size() - 1};
+    while (i > 0 && nums[i - 1] < nums[i]) --i;
+    return i;
   }
 };

--- a/old-problems/3818/solution.cpp
+++ b/old-problems/3818/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int minimumPrefixLength(std::vector<int>& nums) {
+    return nums.size();
+  }
+};

--- a/old-problems/3818/test.yaml
+++ b/old-problems/3818/test.yaml
@@ -1,0 +1,26 @@
+name: 3818. Minimum Prefix Removal to Make Array Strictly Increasing
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: minimumPrefixLength
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [1, -1, 2, 3, 3, 4, 5]
+    output: 4
+
+  example_2:
+    inputs:
+      nums: [4, 3, -2, -5]
+    output: 3
+
+  example_3:
+    inputs:
+      nums: [1, 2, 3, 4]
+    output: 0


### PR DESCRIPTION
This pull request resolves #5289 by solving the problem [3818. Minimum Prefix Removal to Make Array Strictly Increasing](https://leetcode.com/problems/minimum-prefix-removal-to-make-array-strictly-increasing/) in C++. It does so by finding the first non-increasing index from the right.