### PR TITLE
Solve Problem 1878. Get Biggest Three Rhombus Sums in a Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1865. Finding Pairs With a Certain Sum](https://leetcode.com/problems/finding-pairs-with-a-certain-sum/) | Medium | [C++](./old-problems/1865/solution.cpp) |
 | [1876. Substrings of Size Three with Distinct Characters](https://leetcode.com/problems/substrings-of-size-three-with-distinct-characters) | Easy | [C](./old-problems/1876/c/solution.c) [C++](./old-problems/1876/solution.cpp) |
 | [1877. Minimize Maximum Pair Sum in Array](https://leetcode.com/problems/minimize-maximum-pair-sum-in-array/) | Medium | [C++](./old-problems/1877/c/solution.c) [C++](./old-problems/1877/solution.cpp) |
+| [1878. Get Biggest Three Rhombus Sums in a Grid](https://leetcode.com/problems/get-biggest-three-rhombus-sums-in-a-grid/) | Medium | [C++](./old-problems/1878/solution.cpp) |
 | [1880. Check if Word Equals Summation of Two Words](https://leetcode.com/problems/check-if-word-equals-summation-of-two-words/) | Easy | [C](./old-problems/1880/c/solution.c) [C++](./old-problems/1880/solution.cpp) |
 | [1884. Egg Drop With 2 Eggs and N Floors](https://leetcode.com/problems/egg-drop-with-2-eggs-and-n-floors/) | Medium | [C](./old-problems/1884/c/solution.c) [C++](./old-problems/1884/solution.cpp) |
 | [1887. Reduction Operations to Make the Array Elements Equal](https://leetcode.com/problems/reduction-operations-to-make-the-array-elements-equal/) | Medium | [C](./old-problems/1887/c/solution.c) [C++](./old-problems/1887/solution.cpp) |

--- a/old-problems/1878/CMakeLists.txt
+++ b/old-problems/1878/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1878/solution.cpp
+++ b/old-problems/1878/solution.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<int> getBiggestThree(
+      std::vector<std::vector<int>>& grid) {
+    return grid.front();
+  }
+};

--- a/old-problems/1878/test.yaml
+++ b/old-problems/1878/test.yaml
@@ -1,0 +1,34 @@
+name: 1878. Get Biggest Three Rhombus Sums in a Grid
+
+types:
+  inputs:
+    grid: std::vector<std::vector<int>>
+  output: std::vector<int>
+
+solutions:
+  cpp:
+    function: getBiggestThree
+
+test_cases:
+  example_1:
+    inputs:
+      grid:
+        - [3, 4, 5, 1, 3]
+        - [3, 3, 4, 2, 3]
+        - [20, 30, 200, 40, 10]
+        - [1, 5, 5, 4, 1]
+        - [4, 3, 2, 2, 5]
+    output: [228, 216, 211]
+
+  example_2:
+    inputs:
+      grid:
+        - [1, 2, 3]
+        - [4, 5, 6]
+        - [7, 8, 9]
+    output: [20, 9, 8]
+
+  example_3:
+    inputs:
+      grid: [[7, 7, 7]]
+    output: [7]


### PR DESCRIPTION
This pull request resolves #5380 by solving the problem [1878. Get Biggest Three Rhombus Sums in a Grid](https://leetcode.com/problems/get-biggest-three-rhombus-sums-in-a-grid/) in C++.