### PR TITLE
Solve Problem 3857. Minimum Cost to Split into Ones in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1361,7 +1361,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3798. Largest Even Number](https://leetcode.com/problems/largest-even-number/) | Easy | [C](./old-problems/3798/c/solution.c) [C++](./old-problems/3798/solution.cpp) |
 | [3804. Number of Centered Subarrays](https://leetcode.com/problems/number-of-centered-subarrays/) | Medium | [C](./old-problems/3804/c/solution.c) [C++](./old-problems/3804/solution.cpp) |
 | [3823. Reverse Letters Then Special Characters in a String](https://leetcode.com/problems/reverse-letters-then-special-characters-in-a-string/) | Easy | [C](./old-problems/3823/c/solution.c) [C++](./old-problems/3823/solution.cpp) |
-| [3857. Minimum Cost to Split into Ones](https://leetcode.com/problems/minimum-cost-to-split-into-ones/) | Medium | [C++](./old-problems/3857/solution.cpp) |
+| [3857. Minimum Cost to Split into Ones](https://leetcode.com/problems/minimum-cost-to-split-into-ones/) | Medium | [C](./old-problems/3857/c/solution.c) [C++](./old-problems/3857/solution.cpp) |
 | [3861. Minimum Capacity Box](https://leetcode.com/problems/minimum-capacity-box/) | Easy | [C](./old-problems/3861/c/solution.c) [C++](./old-problems/3861/solution.cpp) |
 
 ## License

--- a/old-problems/3857/CMakeLists.txt
+++ b/old-problems/3857/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3857/c/interface.cpp
+++ b/old-problems/3857/c/interface.cpp
@@ -1,0 +1,7 @@
+extern "C" {
+int minCost(int n);
+}
+
+int solution_c(int n) {
+  return minCost(n);
+}

--- a/old-problems/3857/c/solution.c
+++ b/old-problems/3857/c/solution.c
@@ -1,3 +1,3 @@
 int minCost(int n) {
-  return n;
+  return n * (n - 1) / 2;
 }

--- a/old-problems/3857/c/solution.c
+++ b/old-problems/3857/c/solution.c
@@ -1,0 +1,3 @@
+int minCost(int n) {
+  return n;
+}

--- a/old-problems/3857/test.yaml
+++ b/old-problems/3857/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minCost
 


### PR DESCRIPTION
This pull request resolves #5452 by solving the problem [3857. Minimum Cost to Split into Ones](https://leetcode.com/problems/minimum-cost-to-split-into-ones/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #5349.