### PR TITLE
Solve Problem 3740. Minimum Distance Between Three Equal Elements I in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1350,7 +1350,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3726. Remove Zeros in Decimal Representation](https://leetcode.com/problems/remove-zeros-in-decimal-representation/) | Easy | [C](./old-problems/3726/c/solution.c) [C++](./old-problems/3726/solution.cpp) |
 | [3731. Find Missing Elements](https://leetcode.com/problems/find-missing-elements/) | Easy | [C](./old-problems/3731/c/solution.c) [C++](./old-problems/3731/solution.cpp) |
 | [3736. Minimum Moves to Equal Array Elements III](https://leetcode.com/problems/minimum-moves-to-equal-array-elements-iii/) | Easy | [C](./old-problems/3736/c/solution.c) [C++](./old-problems/3736/solution.cpp) |
-| [3740. Minimum Distance Between Three Equal Elements I](https://leetcode.com/problems/minimum-distance-between-three-equal-elements-i/) | Easy | [C++](./old-problems/3740/solution.cpp) |
+| [3740. Minimum Distance Between Three Equal Elements I](https://leetcode.com/problems/minimum-distance-between-three-equal-elements-i/) | Easy | [C](./old-problems/3740/c/solution.c) [C++](./old-problems/3740/solution.cpp) |
 | [3745. Maximize Expression of Three Elements](https://leetcode.com/problems/maximize-expression-of-three-elements/) | Easy | [C](./old-problems/3745/c/solution.c) [C++](./old-problems/3745/solution.cpp) |
 | [3746. Minimum String Length After Balanced Removals](https://leetcode.com/problems/minimum-string-length-after-balanced-removals/) | Medium | [C](./old-problems/3746/c/solution.c) [C++](./old-problems/3746/solution.cpp) |
 | [3750. Minimum Number of Flips to Reverse Binary String](https://leetcode.com/problems/minimum-number-of-flips-to-reverse-binary-string/) | Easy | [C](./old-problems/3750/c/solution.c) [C++](./old-problems/3750/solution.cpp) |

--- a/old-problems/3740/CMakeLists.txt
+++ b/old-problems/3740/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3740/c/interface.cpp
+++ b/old-problems/3740/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minimumDistance(int* nums, int numsSize);
+}
+
+int solution_c(std::vector<int> nums) {
+  return minimumDistance(nums.data(), nums.size());
+}

--- a/old-problems/3740/c/solution.c
+++ b/old-problems/3740/c/solution.c
@@ -1,0 +1,3 @@
+int minimumDistance(int* nums, int numsSize) {
+  return nums[numsSize - 1];
+}

--- a/old-problems/3740/c/solution.c
+++ b/old-problems/3740/c/solution.c
@@ -1,3 +1,16 @@
 int minimumDistance(int* nums, int numsSize) {
-  return nums[numsSize - 1];
+  int minDist = numsSize * 3;
+  for (int i = 0; i < numsSize; ++i) {
+    for (int j = i + 1; j < numsSize; ++j) {
+      if (nums[i] == nums[j]) {
+        for (int k = j + 1; k < numsSize; ++k) {
+          if (nums[j] == nums[k]) {
+            const int dist = 2 * (k - i);
+            if (dist < minDist) minDist = dist;
+          }
+        }
+      }
+    }
+  }
+  return minDist == numsSize * 3 ? -1 : minDist;
 }

--- a/old-problems/3740/test.yaml
+++ b/old-problems/3740/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minimumDistance
 


### PR DESCRIPTION
This pull request resolves #5458 by solving the problem [3740. Minimum Distance Between Three Equal Elements I](https://leetcode.com/problems/minimum-distance-between-three-equal-elements-i/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #5455.