### PR TITLE
Solve Problem 3666. Minimum Operations to Equalize Binary String in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,7 +1339,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3653. XOR After Range Multiplication Queries I](https://leetcode.com/problems/xor-after-range-multiplication-queries-i/) | Medium | [C](./old-problems/3653/c/solution.c) [C++](./old-problems/3653/solution.cpp) |
 | [3658. GCD of Odd and Even Sums](https://leetcode.com/problems/gcd-of-odd-and-even-sums/) | Easy | [C](./old-problems/3658/c/solution.c) [C++](./old-problems/3658/solution.cpp) |
 | [3663. Find The Least Frequent Digit](https://leetcode.com/problems/find-the-least-frequent-digit/) | Easy | [C](./old-problems/3663/c/solution.c) [C++](./old-problems/3663/solution.cpp) |
-| [3666. Minimum Operations to Equalize Binary String](https://leetcode.com/problems/minimum-operations-to-equalize-binary-string/) | Hard | [C++](./old-problems/3666/solution.cpp) |
+| [3666. Minimum Operations to Equalize Binary String](https://leetcode.com/problems/minimum-operations-to-equalize-binary-string/) | Hard | [C](./old-problems/3666/c/solution.c) [C++](./old-problems/3666/solution.cpp) |
 | [3668. Restore Finishing Order](https://leetcode.com/problems/restore-finishing-order/) | Easy | [C](./old-problems/3668/c/solution.c) [C++](./old-problems/3668/solution.cpp) |
 | [3683. Earliest Time to Finish One Task](https://leetcode.com/problems/earliest-time-to-finish-one-task/) | Easy | [C](./old-problems/3683/c/solution.c) [C++](./old-problems/3683/solution.cpp) |
 | [3684. Maximize Sum of At Most K Distinct Elements](https://leetcode.com/problems/maximize-sum-of-at-most-k-distinct-elements/) | Easy | [C](./old-problems/3684/c/solution.c) [C++](./old-problems/3684/solution.cpp) |

--- a/old-problems/3666/CMakeLists.txt
+++ b/old-problems/3666/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3666/c/interface.cpp
+++ b/old-problems/3666/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <string>
+
+extern "C" {
+int minOperations(char* s, int k);
+}
+
+int solution_c(std::string s, int k) {
+  return minOperations(s.data(), k);
+}

--- a/old-problems/3666/c/solution.c
+++ b/old-problems/3666/c/solution.c
@@ -1,3 +1,28 @@
 int minOperations(char* s, int k) {
-  return *s + k;
+  int n = 0, zeros = 0;
+  while (s[n] != 0) {
+    if (s[n] == '0') ++zeros;
+    ++n;
+  }
+
+  if (zeros == 0) return 0;
+  if (n == k) return zeros == k ? 1 : -1;
+
+  const int ones = n - zeros;
+  const int nk = n - k;
+
+  const int even0 = (zeros + k - 1) / k;
+  const int even1 = (zeros + nk - 1) / nk;
+  int even = even0 > even1 ? even0 : even1;
+  if (even % 2 == 1) ++even;
+
+  if (k % 2 == zeros % 2) {
+    const int odd0 = (zeros + k - 1) / k;
+    const int odd1 = (ones + nk - 1) / nk;
+    int odd = odd0 > odd1 ? odd0 : odd1;
+    if (odd % 2 == 0) ++odd;
+    return zeros % 2 == 0 ? (even < odd ? even : odd) : odd;
+  }
+
+  return zeros % 2 == 0 ? even : -1;
 }

--- a/old-problems/3666/c/solution.c
+++ b/old-problems/3666/c/solution.c
@@ -1,0 +1,3 @@
+int minOperations(char* s, int k) {
+  return *s + k;
+}

--- a/old-problems/3666/test.yaml
+++ b/old-problems/3666/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minOperations
 


### PR DESCRIPTION
This pull request resolves #5466 by solving the problem [3666. Minimum Operations to Equalize Binary String](https://leetcode.com/problems/minimum-operations-to-equalize-binary-string/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #5332.