### PR TITLE
Solve Problem 3507. Minimum Pair Removal to Sort Array I in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1314,7 +1314,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3494. Find the Minimum Amount of Time to Brew Potions](https://leetcode.com/problems/find-the-minimum-amount-of-time-to-brew-potions/) | Medium | [C](./old-problems/3494/c/solution.c) [C++](./old-problems/3494/solution.cpp) |
 | [3498. Reverse Degree of a String](https://leetcode.com/problems/reverse-degree-of-a-string/) | Easy | [C](./old-problems/3498/c/solution.c) [C++](./old-problems/3498/solution.cpp) |
 | [3502. Minimum Cost to Reach Every Position](https://leetcode.com/problems/minimum-cost-to-reach-every-position/) | Easy | [C](./old-problems/3502/c/solution.c) [C++](./old-problems/3502/solution.cpp) |
-| [3507. Minimum Pair Removal to Sort Array I](https://leetcode.com/problems/minimum-pair-removal-to-sort-array-i/) | Easy | [C++](./old-problems/3507/solution.cpp) |
+| [3507. Minimum Pair Removal to Sort Array I](https://leetcode.com/problems/minimum-pair-removal-to-sort-array-i/) | Easy | [C](./old-problems/3507/c/solution.c) [C++](./old-problems/3507/solution.cpp) |
 | [3508. Implement Router](https://leetcode.com/problems/implement-router/) | Medium | [C++](./old-problems/3508/solution.cpp) |
 | [3512. Minimum Operations to Make Array Sum Divisible by K](https://leetcode.com/problems/minimum-operations-to-make-array-sum-divisible-by-k/) | Easy | [C](./old-problems/3512/c/solution.c) [C++](./old-problems/3512/solution.cpp) |
 | [3516. Find Closest Person](https://leetcode.com/problems/find-closest-person/) | Easy | [C](./old-problems/3516/c/solution.c) [C++](./old-problems/3516/solution.cpp) |

--- a/old-problems/3507/CMakeLists.txt
+++ b/old-problems/3507/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3507/c/interface.cpp
+++ b/old-problems/3507/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minimumPairRemoval(int* nums, int numsSize);
+}
+
+int solution_c(std::vector<int> nums) {
+  return minimumPairRemoval(nums.data(), nums.size());
+}

--- a/old-problems/3507/c/solution.c
+++ b/old-problems/3507/c/solution.c
@@ -1,0 +1,3 @@
+int minimumPairRemoval(int* nums, int numsSize) {
+  return nums[numsSize - 1];
+}

--- a/old-problems/3507/c/solution.c
+++ b/old-problems/3507/c/solution.c
@@ -1,3 +1,33 @@
+#include <limits.h>
+
 int minimumPairRemoval(int* nums, int numsSize) {
-  return nums[numsSize - 1];
+  const int prevSize = numsSize;
+  while (numsSize > 1) {
+    int minSum = INT_MAX, i = 1, minI = 0;
+    while (i < numsSize && nums[i] >= nums[i - 1]) {
+      if (nums[i] + nums[i - 1] < minSum) {
+        minSum = nums[i] + nums[i - 1];
+        minI = i;
+      }
+      ++i;
+    }
+
+    if (i == numsSize) break;
+
+    while (i < numsSize) {
+      if (nums[i] + nums[i - 1] < minSum) {
+        minSum = nums[i] + nums[i - 1];
+        minI = i;
+      }
+      ++i;
+    }
+
+    nums[minI - 1] = minSum;
+    for (int i = minI + 1; i < numsSize; ++i) {
+      nums[i - 1] = nums[i];
+    }
+    --numsSize;
+  }
+
+  return prevSize - numsSize;
 }

--- a/old-problems/3507/test.yaml
+++ b/old-problems/3507/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minimumPairRemoval
 


### PR DESCRIPTION
This pull request resolves #5474 by solving the problem [3507. Minimum Pair Removal to Sort Array I](https://leetcode.com/problems/minimum-pair-removal-to-sort-array-i/) in C. It does so by implementing the same solution as the C++ solution to the problem implemented in #5138.