### PR TITLE
Solve Problem 3761. Minimum Absolute Distance Between Mirror Pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1359,6 +1359,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3750. Minimum Number of Flips to Reverse Binary String](https://leetcode.com/problems/minimum-number-of-flips-to-reverse-binary-string/) | Easy | [C](./old-problems/3750/c/solution.c) [C++](./old-problems/3750/solution.cpp) |
 | [3751. Total Waviness of Numbers in Range I](https://leetcode.com/problems/total-waviness-of-numbers-in-range-i/) | Medium | [C](./old-problems/3751/c/solution.c) [C++](./old-problems/3751/solution.cpp) |
 | [3760. Maximum Substrings With Distinct Start](https://leetcode.com/problems/maximum-substrings-with-distinct-start/) | Medium | [C](./old-problems/3760/c/solution.c) [C++](./old-problems/3760/solution.cpp) |
+| [3761. Minimum Absolute Distance Between Mirror Pairs](https://leetcode.com/problems/minimum-absolute-distance-between-mirror-pairs/) | Medium | [C++](./old-problems/3761/solution.cpp) |
 | [3775. Reverse Words With Same Vowel Count](https://leetcode.com/problems/maximum-substrings-with-distinct-start/) | Medium | [C](./old-problems/3775/c/solution.c) [C++](./old-problems/3775/solution.cpp) |
 | [3783. Mirror Distance of an Integer](https://leetcode.com/problems/mirror-distance-of-an-integer/) | Easy | [C](./old-problems/3783/c/solution.c) [C++](./old-problems/3783/solution.cpp) |
 | [3794. Reverse String Prefix](https://leetcode.com/problems/reverse-string-prefix/) | Easy | [C](./old-problems/3794/c/solution.c) [C++](./old-problems/3794/solution.cpp) |

--- a/old-problems/3761/CMakeLists.txt
+++ b/old-problems/3761/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3761/solution.cpp
+++ b/old-problems/3761/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int minMirrorPairDistance(std::vector<int>& nums) {
+    return nums.size();
+  }
+};

--- a/old-problems/3761/solution.cpp
+++ b/old-problems/3761/solution.cpp
@@ -1,8 +1,31 @@
+#include <unordered_map>
 #include <vector>
 
 class Solution {
  public:
   int minMirrorPairDistance(std::vector<int>& nums) {
-    return nums.size();
+    std::size_t minDistance{nums.size()};
+    std::unordered_map<int, std::size_t> mirrorIndices{};
+    for (std::size_t i{0}; i < nums.size(); ++i) {
+      int num{nums[i]};
+      const auto it = mirrorIndices.find(num);
+      if (it != mirrorIndices.end()) {
+        if (i - it->second < minDistance) minDistance = i - it->second;
+      }
+
+      int mirror{0};
+      while (num != 0) {
+        mirror = mirror * 10 + num % 10;
+        num /= 10;
+      }
+
+      auto mirrorIt = mirrorIndices.find(mirror);
+      if (mirrorIt != mirrorIndices.end()) {
+        mirrorIt->second = i;
+      } else {
+        mirrorIndices.emplace(mirror, i);
+      }
+    }
+    return minDistance == nums.size() ? -1 : minDistance;
   }
 };

--- a/old-problems/3761/test.yaml
+++ b/old-problems/3761/test.yaml
@@ -1,0 +1,26 @@
+name: 3761. Minimum Absolute Distance Between Mirror Pairs
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: int
+
+solutions:
+  cpp:
+    function: minMirrorPairDistance
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [12, 21, 45, 33, 54]
+    output: 1
+
+  example_2:
+    inputs:
+      nums: [120, 21]
+    output: 1
+
+  example_3:
+    inputs:
+      nums: [21, 120]
+    output: -1


### PR DESCRIPTION
This pull request resolves #5478 by solving the problem [3761. Minimum Absolute Distance Between Mirror Pairs](https://leetcode.com/problems/minimum-absolute-distance-between-mirror-pairs/) in C++. It does so by keeping track of mirror indices while iterating the given array.