### PR TITLE
Solve problem 3917. Count Indices With Opposite Parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1394,6 +1394,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3870. Count Commas in Range](https://leetcode.com/problems/count-commas-in-range/) | Easy | [C](./old-problems/3870/c/solution.c) [C++](./old-problems/3870/solution.cpp) |
 | [3894. Traffic Signal Color](https://leetcode.com/problems/traffic-signal-color/) | Easy | [C](./old-problems/3894/c/solution.c) [C++](./old-problems/3894/solution.cpp) |
 | [3898. Find the Degree of Each Vertex](https://leetcode.com/problems/find-the-degree-of-each-vertex/) | Easy | [C++](./old-problems/3898/solution.cpp) |
+| [3917. Count Indices With Opposite Parity](https://leetcode.com/problems/count-indices-with-opposite-parity/) | Easy | [C++](./old-problems/3917/solution.cpp) |
 
 ## License
 

--- a/old-problems/3917/CMakeLists.txt
+++ b/old-problems/3917/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3917/solution.cpp
+++ b/old-problems/3917/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  std::vector<int> countOppositeParity(std::vector<int>& nums) {
+    return nums;
+  }
+};

--- a/old-problems/3917/solution.cpp
+++ b/old-problems/3917/solution.cpp
@@ -3,6 +3,17 @@
 class Solution {
  public:
   std::vector<int> countOppositeParity(std::vector<int>& nums) {
+    int even{0}, odd{0};
+    for (std::size_t i{nums.size()}; i > 0;) {
+      --i;
+      if (nums[i] % 2 == 0) {
+        nums[i] = odd;
+        ++even;
+      } else {
+        nums[i] = even;
+        ++odd;
+      }
+    }
     return nums;
   }
 };

--- a/old-problems/3917/test.yaml
+++ b/old-problems/3917/test.yaml
@@ -1,0 +1,21 @@
+name: 3917. Count Indices With Opposite Parity
+
+types:
+  inputs:
+    nums: std::vector<int>
+  output: std::vector<int>
+
+solutions:
+  cpp:
+    function: countOppositeParity
+
+test_cases:
+  example_1:
+    inputs:
+      nums: [1, 2, 3, 4]
+    output: [2, 1, 1, 0]
+
+  example_2:
+    inputs:
+      nums: [1]
+    output: [0]


### PR DESCRIPTION
This pull request resolves #5546 by solving the problem [3917. Count Indices With Opposite Parity](https://leetcode.com/problems/count-indices-with-opposite-parity/) in C++ using a for-loop.