### PR TITLE
Solve Problem 3918. Sum of Primes Between Number and Its Reverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -1400,6 +1400,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3898. Find the Degree of Each Vertex](https://leetcode.com/problems/find-the-degree-of-each-vertex/) | Easy | [C](./old-problems/3898/c/solution.c) [C++](./old-problems/3898/solution.cpp) |
 | [3904. Smallest Stable Index II](https://leetcode.com/problems/smallest-stable-index-ii/) | Medium | [C++](./old-problems/3904/solution.cpp) |
 | [3917. Count Indices With Opposite Parity](https://leetcode.com/problems/count-indices-with-opposite-parity/) | Easy | [C++](./old-problems/3917/solution.cpp) |
+| [3918. Sum of Primes Between Number and Its Reverse](https://leetcode.com/problems/sum-of-primes-between-number-and-its-reverse/) | Medium | [C++](./old-problems/3918/solution.cpp) |
 
 ## License
 

--- a/old-problems/3918/CMakeLists.txt
+++ b/old-problems/3918/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/3918/solution.cpp
+++ b/old-problems/3918/solution.cpp
@@ -1,6 +1,26 @@
+#include <vector>
+
 class Solution {
  public:
   int sumOfPrimesInRange(int n) {
-    return n;
+    int rn{0};
+    for (int nn{n}; nn != 0; nn /= 10) {
+      rn = rn * 10 + nn % 10;
+    }
+
+    const int min{rn < n ? rn : n};
+    const int max{rn > n ? rn : n};
+
+    int sum{0};
+    std::vector<bool> sieve(max + 1, false);
+    for (int i{2}; i <= max; ++i) {
+      if (sieve[i]) continue;
+      if (i >= min) sum += i;
+      for (int j{i}; j <= max; j += i) {
+        sieve[j] = true;
+      }
+    }
+
+    return sum;
   }
 };

--- a/old-problems/3918/solution.cpp
+++ b/old-problems/3918/solution.cpp
@@ -1,0 +1,6 @@
+class Solution {
+ public:
+  int sumOfPrimesInRange(int n) {
+    return n;
+  }
+};

--- a/old-problems/3918/test.yaml
+++ b/old-problems/3918/test.yaml
@@ -1,0 +1,26 @@
+name: 3918. Sum of Primes Between Number and Its Reverse
+
+types:
+  inputs:
+    n: int
+  output: int
+
+solutions:
+  cpp:
+    function: sumOfPrimesInRange
+
+test_cases:
+  example_1:
+    inputs:
+      n: 13
+    output: 132
+
+  example_2:
+    inputs:
+      n: 10
+    output: 17
+
+  example_3:
+    inputs:
+      n: 8
+    output: 0


### PR DESCRIPTION
This pull request resolves #5582 by adding a C++ solution for [3918. Sum of Primes Between Number and Its Reverse](https://leetcode.com/problems/sum-of-primes-between-number-and-its-reverse/) using the Sieve of Eratosthenes.
