### PR TITLE
Solve problem 1674. Minimum Moves to Make Array Complementary in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1669. Merge In Between Linked Lists](https://leetcode.com/problems/merge-in-between-linked-lists/) | Medium | [C++](./old-problems/1669/solution.cpp) |
 | [1671. Minimum Number of Removals to Make Mountain Array](https://leetcode.com/problems/minimum-number-of-removals-to-make-mountain-array/) | Hard | [C++](./old-problems/1671/solution.cpp) |
 | [1672. Richest Customer Wealth](https://leetcode.com/problems/richest-customer-wealth/) | Easy | [C](./old-problems/1672/c/solution.c) [C++](./old-problems/1672/solution.cpp) |
-| [1674. Minimum Moves to Make Array Complementary](https://leetcode.com/problems/minimum-moves-to-make-array-complementary/) | Medium | [C++](./old-problems/1674/solution.cpp) |
+| [1674. Minimum Moves to Make Array Complementary](https://leetcode.com/problems/minimum-moves-to-make-array-complementary/) | Medium | [C](./old-problems/1674/c/solution.c) [C++](./old-problems/1674/solution.cpp) |
 | [1678. Goal Parser Interpretation](https://leetcode.com/problems/goal-parser-interpretation/) | Easy | [C](./old-problems/1678/c/solution.c) [C++](./old-problems/1678/solution.cpp) |
 | [1680. Concatenation of Consecutive Binary Numbers](https://leetcode.com/problems/concatenation-of-consecutive-binary-numbers/) | Medium | [C](./old-problems/1680/c/solution.c) [C++](./old-problems/1680/solution.cpp) |
 | [1684. Count the Number of Consistent Strings](https://leetcode.com/problems/count-the-number-of-consistent-strings/) | Easy | [C++](./old-problems/1684/solution.cpp) |

--- a/old-problems/1674/CMakeLists.txt
+++ b/old-problems/1674/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/1674/c/interface.cpp
+++ b/old-problems/1674/c/interface.cpp
@@ -1,0 +1,9 @@
+#include <vector>
+
+extern "C" {
+int minMoves(int* nums, int numsSize, int limit);
+}
+
+int solution_c(std::vector<int> nums, int limit) {
+  return minMoves(nums.data(), nums.size(), limit);
+}

--- a/old-problems/1674/c/solution.c
+++ b/old-problems/1674/c/solution.c
@@ -1,3 +1,25 @@
+#include <stdlib.h>
+
 int minMoves(int* nums, int numsSize, int limit) {
-  return nums[numsSize - 1] + limit;
+  const int limit2 = 2 * limit;
+  const int prefixMovesSize = limit2 + 2;
+  int* prefixMoves = malloc(prefixMovesSize * sizeof(int));
+  for (int i = 0; i < prefixMovesSize; ++i) prefixMoves[i] = 0;
+
+  prefixMoves[2] += numsSize;
+  for (int l = 0, r = numsSize - 1; l < r; ++l, --r) {
+    --prefixMoves[(nums[l] < nums[r] ? nums[l] : nums[r]) + 1];
+    --prefixMoves[nums[l] + nums[r]];
+    ++prefixMoves[nums[l] + nums[r] + 1];
+    ++prefixMoves[(nums[l] > nums[r] ? nums[l] : nums[r]) + limit + 1];
+  }
+
+  int moves = prefixMoves[2], minMoves = moves;
+  for (int i = 3; i <= limit2; ++i) {
+    moves += prefixMoves[i];
+    if (moves < minMoves) minMoves = moves;
+  }
+
+  free(prefixMoves);
+  return minMoves;
 }

--- a/old-problems/1674/c/solution.c
+++ b/old-problems/1674/c/solution.c
@@ -1,0 +1,3 @@
+int minMoves(int* nums, int numsSize, int limit) {
+  return nums[numsSize - 1] + limit;
+}

--- a/old-problems/1674/test.yaml
+++ b/old-problems/1674/test.yaml
@@ -7,6 +7,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: minMoves
 


### PR DESCRIPTION
This pull request resolves #5604 by adding a C solution for [1674. Minimum Moves to Make Array Complementary](https://leetcode.com/problems/minimum-moves-to-make-array-complementary/) using the same approach as the C++ solution implemented in #5577.
