### PR TITLE
Solve problem 3918. Sum of Primes Between Number and Its Reverse in C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1406,7 +1406,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [3898. Find the Degree of Each Vertex](https://leetcode.com/problems/find-the-degree-of-each-vertex/) | Easy | [C](./old-problems/3898/c/solution.c) [C++](./old-problems/3898/solution.cpp) |
 | [3904. Smallest Stable Index II](https://leetcode.com/problems/smallest-stable-index-ii/) | Medium | [C](./old-problems/3904/c/solution.c) [C++](./old-problems/3904/solution.cpp) |
 | [3917. Count Indices With Opposite Parity](https://leetcode.com/problems/count-indices-with-opposite-parity/) | Easy | [C](./old-problems/3917/c/solution.c) [C++](./old-problems/3917/solution.cpp) |
-| [3918. Sum of Primes Between Number and Its Reverse](https://leetcode.com/problems/sum-of-primes-between-number-and-its-reverse/) | Medium | [C++](./old-problems/3918/solution.cpp) |
+| [3918. Sum of Primes Between Number and Its Reverse](https://leetcode.com/problems/sum-of-primes-between-number-and-its-reverse/) | Medium | [C](./old-problems/3918/c/solution.c) [C++](./old-problems/3918/solution.cpp) |
 
 ## License
 

--- a/old-problems/3918/CMakeLists.txt
+++ b/old-problems/3918/CMakeLists.txt
@@ -1,2 +1,5 @@
+add_c_solution(c_solution c/interface.cpp c/solution.c)
+
 get_dir_name(id)
 add_problem_test(test-${id} test.yaml)
+target_link_libraries(test-${id} PRIVATE ${c_solution})

--- a/old-problems/3918/c/interface.cpp
+++ b/old-problems/3918/c/interface.cpp
@@ -1,0 +1,7 @@
+extern "C" {
+int sumOfPrimesInRange(int n);
+}
+
+int solution_c(int n) {
+  return sumOfPrimesInRange(n);
+}

--- a/old-problems/3918/c/solution.c
+++ b/old-problems/3918/c/solution.c
@@ -1,0 +1,3 @@
+int sumOfPrimesInRange(int n) {
+  return n;
+}

--- a/old-problems/3918/c/solution.c
+++ b/old-problems/3918/c/solution.c
@@ -1,3 +1,27 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
 int sumOfPrimesInRange(int n) {
-  return n;
+  int rn = 0;
+  for (int nn = n; nn != 0; nn /= 10) {
+    rn = rn * 10 + nn % 10;
+  }
+
+  const int min = rn < n ? rn : n;
+  const int max = rn > n ? rn : n;
+
+  int sum = 0;
+  uint8_t* sieve = malloc((max / 8 + 1) * sizeof(uint8_t));
+  memset(sieve, 0, (max / 8 + 1) * sizeof(uint8_t));
+
+  for (int i = 2; i <= max; ++i) {
+    if ((sieve[i / 8] & (1 << (i % 8))) != 0) continue;
+    if (i >= min) sum += i;
+    for (int j = i; j <= max; j += i) {
+      sieve[j / 8] |= 1 << (j % 8);
+    }
+  }
+
+  return sum;
 }

--- a/old-problems/3918/test.yaml
+++ b/old-problems/3918/test.yaml
@@ -6,6 +6,7 @@ types:
   output: int
 
 solutions:
+  c:
   cpp:
     function: sumOfPrimesInRange
 


### PR DESCRIPTION
This pull request resolves #5628 by adding C++ solution for [3918. Sum of Primes Between Number and Its Reverse](https://leetcode.com/problems/sum-of-primes-between-number-and-its-reverse/).

It does so by implementing the same solution as C++ solution in #5583.