### PR TITLE
Solve problem 2095. Delete the Middle Node of a Linked List

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,6 +899,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [2089. Find Target Indices After Sorting Array](https://leetcode.com/problems/find-target-indices-after-sorting-array/) | Easy | [C](./old-problems/2089/c/solution.c) [C++](./old-problems/2089/solution.cpp) |
 | [2092. Find All People With Secret](https://leetcode.com/problems/find-all-people-with-secret/) | Hard | [C](./old-problems/2092/c/solution.c) [C++](./old-problems/2092/solution.cpp) |
 | [2094. Finding 3-Digit Even Numbers](https://leetcode.com/problems/finding-3-digit-even-numbers/) | Easy | [C](./old-problems/2094/c/solution.c) [C++](./old-problems/2094/solution.cpp) |
+| [2095. Delete the Middle Node of a Linked List](https://leetcode.com/problems/delete-the-middle-node-of-a-linked-list/) | Medium | [C++](./old-problems/2095/solution.cpp) |
 | [2096. Step-By-Step Directions From a Binary Tree Node to Another](https://leetcode.com/problems/step-by-step-directions-from-a-binary-tree-node-to-another/) | Medium | [C++](./old-problems/2096/solution.cpp) |
 | [2099. Find Subsequence of Length K With the Largest Sum](https://leetcode.com/problems/find-subsequence-of-length-k-with-the-largest-sum/) | Easy | [C](./old-problems/2099/c/solution.c) [C++](./old-problems/2099/solution.cpp) |
 | [2103. Rings and Rods](https://leetcode.com/problems/rings-and-rods/) | Easy | [C](./old-problems/2103/c/solution.c) [C++](./old-problems/2103/solution.cpp) |

--- a/old-problems/2095/CMakeLists.txt
+++ b/old-problems/2095/CMakeLists.txt
@@ -1,0 +1,6 @@
+get_dir_name(id)
+
+add_executable(test-${id} test.cpp)
+target_link_libraries(test-${id} PRIVATE Catch2::Catch2WithMain)
+
+catch_discover_tests(test-${id})

--- a/old-problems/2095/solution.cpp
+++ b/old-problems/2095/solution.cpp
@@ -1,0 +1,6 @@
+class Solution {
+ public:
+  ListNode* deleteMiddle(ListNode* head) {
+    return head;
+  }
+};

--- a/old-problems/2095/solution.cpp
+++ b/old-problems/2095/solution.cpp
@@ -1,6 +1,14 @@
 class Solution {
  public:
   ListNode* deleteMiddle(ListNode* head) {
+    if (head->next == nullptr) return nullptr;
+    ListNode* slow{head};
+    ListNode* fast{head->next};
+    while (fast->next != nullptr && fast->next->next != nullptr) {
+      slow = slow->next;
+      fast = fast->next->next;
+    }
+    slow->next = slow->next->next;
     return head;
   }
 };

--- a/old-problems/2095/test.cpp
+++ b/old-problems/2095/test.cpp
@@ -1,0 +1,56 @@
+struct ListNode {
+  int val;
+  ListNode* next;
+  ListNode() : val(0), next(nullptr) {}
+  ListNode(int x) : val(x), next(nullptr) {}
+  ListNode(int x, ListNode* next) : val(x), next(next) {}
+};
+
+// clang-format off
+#include "solution.cpp"
+// clang-format on
+
+#include <catch2/catch_test_macros.hpp>
+
+ListNode* tolistNode(const std::vector<int>& nums) {
+  if (nums.empty()) return nullptr;
+  ListNode* head{new ListNode(nums[0])};
+  ListNode* node{head};
+  for (std::size_t i = 1; i < nums.size(); ++i) {
+    node->next = new ListNode(nums[i]);
+    node = node->next;
+  }
+  return head;
+}
+
+std::vector<int> fromListNode(const ListNode* node) {
+  std::vector<int> nums{};
+  while (node != nullptr) {
+    nums.push_back(node->val);
+    node = node->next;
+  }
+  return nums;
+}
+
+TEST_CASE("2095. Delete the Middle Node of a Linked List") {
+  SECTION("Example 1") {
+    ListNode* head{tolistNode({1, 3, 4, 7, 1, 2, 6})};
+    ListNode* actual{Solution{}.deleteMiddle(head)};
+    std::vector<int> expected{1, 3, 4, 1, 2, 6};
+    REQUIRE(fromListNode(actual) == expected);
+  }
+
+  SECTION("Example 2") {
+    ListNode* head{tolistNode({1, 2, 3, 4})};
+    ListNode* actual{Solution{}.deleteMiddle(head)};
+    std::vector<int> expected{1, 2, 4};
+    REQUIRE(fromListNode(actual) == expected);
+  }
+
+  SECTION("Example 3") {
+    ListNode* head{tolistNode({2, 1})};
+    ListNode* actual{Solution{}.deleteMiddle(head)};
+    std::vector<int> expected{2};
+    REQUIRE(fromListNode(actual) == expected);
+  }
+}


### PR DESCRIPTION
This pull request resolves #5663 by adding a C++ solution for [2095. Delete the Middle Node of a Linked List](https://leetcode.com/problems/delete-the-middle-node-of-a-linked-list/).

The implementation uses the slow and fast pointer technique to locate the middle node in a single traversal before removing it from the linked list.
