### PR TITLE
Solve problem 1288. Remove Covered Intervals

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,6 +574,7 @@ LeetSpace serves as a dedicated workspace and archive for my [LeetCode](https://
 | [1284. Minimum Number of Flips to Convert Binary Matrix to Zero Matrix](https://leetcode.com/problems/minimum-number-of-flips-to-convert-binary-matrix-to-zero-matrix/) | Hard | [C](./old-problems/1284/c/solution.c) [C++](./old-problems/1284/solution.cpp) |
 | [1286. Iterator for Combination](https://leetcode.com/problems/iterator-for-combination/) | Medium | [C++](./old-problems/1286/solution.cpp) |
 | [1287. Element Appearing More Than 25% In Sorted Array](https://leetcode.com/problems/element-appearing-more-than-25-in-sorted-array/) | Easy | [C](./old-problems/1287/c/solution.c) [C++](./old-problems/1287/solution.cpp) |
+| [1288. Remove Covered Intervals](https://leetcode.com/problems/remove-covered-intervals/) | Medium | [C++](./old-problems/1288/solution.cpp) |
 | [1289. Minimum Falling Path Sum II](https://leetcode.com/problems/minimum-falling-path-sum-ii/) | Hard | [C](./old-problems/1289/c/solution.c) [C++](./old-problems/1289/solution.cpp) |
 | [1290. Convert Binary Number in a Linked List to Integer](https://leetcode.com/problems/convert-binary-number-in-a-linked-list-to-integer/) | Easy | [C++](./old-problems/1290/solution.cpp) |
 | [1291. Sequential Digits](https://leetcode.com/problems/sequential-digits/) | Medium | [C](./old-problems/1291/c/solution.c) [C++](./old-problems/1291/solution.cpp) |

--- a/old-problems/1288/CMakeLists.txt
+++ b/old-problems/1288/CMakeLists.txt
@@ -1,0 +1,2 @@
+get_dir_name(id)
+add_problem_test(test-${id} test.yaml)

--- a/old-problems/1288/solution.cpp
+++ b/old-problems/1288/solution.cpp
@@ -1,8 +1,24 @@
+#include <algorithm>
 #include <vector>
 
 class Solution {
  public:
   int removeCoveredIntervals(std::vector<std::vector<int>>& intervals) {
-    return intervals.size();
+    std::sort(
+        intervals.begin(), intervals.end(), [](const auto& a, const auto& b) {
+          return a[0] != b[0] ? a[0] < b[0] : a[1] > b[1];
+        });
+
+    std::size_t remainings{intervals.size()};
+    int max{intervals[0][1]};
+    for (std::size_t i{1}; i < intervals.size(); ++i) {
+      if (intervals[i][1] <= max) {
+        --remainings;
+      } else {
+        max = intervals[i][1];
+      }
+    }
+
+    return remainings;
   }
 };

--- a/old-problems/1288/solution.cpp
+++ b/old-problems/1288/solution.cpp
@@ -1,0 +1,8 @@
+#include <vector>
+
+class Solution {
+ public:
+  int removeCoveredIntervals(std::vector<std::vector<int>>& intervals) {
+    return intervals.size();
+  }
+};

--- a/old-problems/1288/test.yaml
+++ b/old-problems/1288/test.yaml
@@ -1,0 +1,21 @@
+name: 1288. Remove Covered Intervals
+
+types:
+  inputs:
+    intervals: std::vector<std::vector<int>>
+  output: int
+
+solutions:
+  cpp:
+    function: removeCoveredIntervals
+
+test_cases:
+  example_1:
+    inputs:
+      intervals: [[1, 4], [3, 6], [2, 8]]
+    output: 2
+
+  example_2:
+    inputs:
+      intervals: [[1, 4], [2, 3]]
+    output: 1


### PR DESCRIPTION
This pull request resolves #5700 by adding a C++ solution for [1288. Remove Covered Intervals](https://leetcode.com/problems/remove-covered-intervals/).

The implementation uses sorting to efficiently identify covered intervals and compute the number of intervals that remain.
